### PR TITLE
Move SWA to westeurope as it's not available in polandcentral

### DIFF
--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -160,7 +160,9 @@ resource migration_job 'Microsoft.App/jobs@2023-05-01' = {
 // --- Static Web App ---
 resource frontend_swa 'Microsoft.Web/staticSites@2022-09-01' = {
   name: 'swa-${prefix}-${env}'
-  location: location
+  // Static Web Apps is a globally distributed service not available in all regions.
+  // Therefore we hardcode the location to westeurope (it's only used for metadata storage).
+  location: 'westeurope'
   sku: {
     name: 'Free'
     tier: 'Free'


### PR DESCRIPTION
Static Web Apps is not available in `polandcentral` but only in [westus2,centralus,eastus2,westeurope,eastasia]. We pick `westeurope`. It's a globally distributed service, this change only affects where the resource metadata and management plane are stored; it has no impact on the performance or availability of your frontend for users.