### PR TITLE
Final round of Bicep infra fixing: ACR resource group, initial hello-world image and per-rg RBAC for OIDC user

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -72,6 +72,11 @@ jobs:
           echo "ACR_NAME=$ACR_NAME" >> $GITHUB_ENV
           echo "DB_HOST=$DB_HOST" >> $GITHUB_ENV
           echo "SNET_ID=$SNET_ID" >> $GITHUB_ENV
+          
+          # Try to get the current image to avoid reverting to hello-world
+          # If the app doesn't exist yet, it will use the Bicep default
+          CURRENT_IMAGE=$(az containerapp show -n ca-spc-${{ env.ENV_NAME }}-backend -g rg-spc-${{ env.ENV_NAME }}-pl --query "properties.template.containers[0].image" -o tsv 2>/dev/null || echo "")
+          echo "CURRENT_IMAGE=$CURRENT_IMAGE" >> $GITHUB_ENV
 
       - name: Create Env RG
         run: az group create --name rg-spc-${{ env.ENV_NAME }}-pl --location polandcentral
@@ -87,5 +92,7 @@ jobs:
             env=${{ env.ENV_NAME }}
             subnetId=${{ env.SNET_ID }}
             acrName=${{ env.ACR_NAME }}
+            acrResourceGroup=rg-spc-shared-pl
             dbHost=${{ env.DB_HOST }}
             dbName=spc_${{ env.ENV_NAME }}
+            ${{ env.CURRENT_IMAGE != '' && format('containerImage={0}', env.CURRENT_IMAGE) || '' }}

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -33,9 +33,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Create Shared RG
-        run: az group create --name rg-spc-shared-pl --location polandcentral
-
       - name: Deploy Shared Bicep
         id: shared_deploy
         uses: azure/arm-deploy@v2
@@ -77,9 +74,6 @@ jobs:
           # If the app doesn't exist yet, it will use the Bicep default
           CURRENT_IMAGE=$(az containerapp show -n ca-spc-${{ env.ENV_NAME }}-backend -g rg-spc-${{ env.ENV_NAME }}-pl --query "properties.template.containers[0].image" -o tsv 2>/dev/null || echo "")
           echo "CURRENT_IMAGE=$CURRENT_IMAGE" >> $GITHUB_ENV
-
-      - name: Create Env RG
-        run: az group create --name rg-spc-${{ env.ENV_NAME }}-pl --location polandcentral
 
       - name: Deploy Env Bicep
         uses: azure/arm-deploy@v2

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -94,11 +94,14 @@ az deployment group validate \
                adminPrincipalName=$(az ad signed-in-user show --query userPrincipalName -o tsv)
 
 # Validate environment-specific infrastructure (e.g., dev)
+# Note: Get the full subnetId from the outputs of your 'shared' deployment:
+# az deployment group show -g rg-spc-shared-pl -n network-deployment --query properties.outputs.snetDevId.value -o tsv
+
 az deployment group validate \
   --resource-group rg-spc-dev-pl \
   --template-file infrastructure/environment.bicep \
   --parameters env=dev \
-               subnetId="/subscriptions/.../subnets/snet-dev" \
+               subnetId="/subscriptions/ca830bff-0330-40f0-8d49-a18d5db67e9c/resourceGroups/rg-spc-shared-pl/providers/Microsoft.Network/virtualNetworks/vnet-spc-shared/subnets/snet-dev" \
                acrName="acrtulspc" \
                acrResourceGroup="rg-spc-shared-pl" \
                dbHost="psql-spc-shared.postgres.database.azure.com" \
@@ -134,8 +137,7 @@ The first deployment must follow a specific order because components depend on e
 ## 4. Architecture Notes
 
 - **Zero-Trust:** No passwords or secrets are stored in GitHub or Azure Key Vault. All services use **Managed Identities**.
-- **Initial Deployment:** The first infrastructure deployment uses a public "hello-world" image (`mcr.microsoft.com/...`) because the ACR is initially empty. 
-- **Image Preservation:** The `infrastructure.yml` workflow is designed to detect if the Container App already exists. If it does, it fetches the current image (e.g., `acrtulspc.azurecr.io/backend:SHA`) and passes it back to Bicep. This prevents infrastructure updates from reverting your app to the "hello-world" placeholder.
+- **Initial Deployment:** The first infrastructure deployment uses a public "hello-world" image (`mcr.microsoft.com/azuredocs/containerapps-helloworld:latest`) because the ACR is initially empty. Furtehr deployments should pass `containerImage=acrtulspc.azurecr.io/backend:latest` to Bicep.
 - **Scale-to-Zero:** The backend (Azure Container Apps) is configured with `minReplicas: 0`. It costs $0 when not in use.
 - **Permission Split:** 
     - The `job-spc-dev-migrate` uses a **DDL Identity** (PostgreSQL Admin) for schema changes.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -37,10 +37,18 @@ APP_OBJECT_ID=$(az ad app show --id $APP_ID --query id -o tsv)
 az ad sp create --id $APP_ID
 SP_OBJECT_ID=$(az ad sp show --id $APP_ID --query id -o tsv)
 
-# Assign 'Contributor' and 'User Access Administrator' roles to the Service Principal
-# 'User Access Administrator' is required for Bicep to create Role Assignments (e.g., AcrPull)
-az role assignment create --role Contributor --assignee $SP_OBJECT_ID --scope "/subscriptions/$SUBSCRIPTION_ID"
-az role assignment create --role "User Access Administrator" --assignee $SP_OBJECT_ID --scope "/subscriptions/$SUBSCRIPTION_ID"
+# Create resource groups and assign roles to the Service Principal scoped to each Resource Group.
+# Note: Roles must be assigned for EACH environment (shared, dev, prod)
+# Not assigning roles at Subscription level to follow the Principle of Least Privilege.
+
+# 1. Create Resource Groups
+# 2. Assign 'Contributor' and 'User Access Administrator' to the SP for each RG
+# User Access Administrator is required for Bicep to create Role Assignments (e.g., AcrPull)
+for rg in "rg-spc-shared-pl" "rg-spc-dev-pl" "rg-spc-prod-pl"; do
+  az group create --name "$rg" --location polandcentral
+  az role assignment create --role Contributor --assignee $SP_OBJECT_ID --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$rg"
+  az role assignment create --role "User Access Administrator" --assignee $SP_OBJECT_ID --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$rg"
+done
 ```
 
 ### Step 2: Configure Federated Identity Credentials
@@ -64,6 +72,8 @@ In your GitHub repository, go to **Settings > Secrets and variables > Actions** 
 - `AZURE_SUBSCRIPTION_ID`: Your Azure Subscription ID.
 - `AZURE_DB_ADMIN_ID`: Your personal Entra ID Object ID (to be the initial DB admin).
 - `AZURE_DB_ADMIN_NAME`: Your personal Entra ID Display Name or Email.
+
+These are not secrets but rather properties that need to be accessible to the GitHub workflows (but they're not secret).
 
 ### Step 4: Use Azure Login in Workflows
 Use `azure/login` [GitHub action](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-azure) to retrieve the Cloud access token in your GitHub workflow.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -37,8 +37,10 @@ APP_OBJECT_ID=$(az ad app show --id $APP_ID --query id -o tsv)
 az ad sp create --id $APP_ID
 SP_OBJECT_ID=$(az ad sp show --id $APP_ID --query id -o tsv)
 
-# Assign 'Contributor' role to the Service Principal
+# Assign 'Contributor' and 'User Access Administrator' roles to the Service Principal
+# 'User Access Administrator' is required for Bicep to create Role Assignments (e.g., AcrPull)
 az role assignment create --role Contributor --assignee $SP_OBJECT_ID --scope "/subscriptions/$SUBSCRIPTION_ID"
+az role assignment create --role "User Access Administrator" --assignee $SP_OBJECT_ID --scope "/subscriptions/$SUBSCRIPTION_ID"
 ```
 
 ### Step 2: Configure Federated Identity Credentials
@@ -97,7 +99,8 @@ az deployment group validate \
   --template-file infrastructure/environment.bicep \
   --parameters env=dev \
                subnetId="/subscriptions/.../subnets/snet-dev" \
-               acrName="acr-spc-shared-pl" \
+               acrName="acrtulspc" \
+               acrResourceGroup="rg-spc-shared-pl" \
                dbHost="psql-spc-shared.postgres.database.azure.com" \
                dbName="spc_dev"
 ```
@@ -131,6 +134,8 @@ The first deployment must follow a specific order because components depend on e
 ## 4. Architecture Notes
 
 - **Zero-Trust:** No passwords or secrets are stored in GitHub or Azure Key Vault. All services use **Managed Identities**.
+- **Initial Deployment:** The first infrastructure deployment uses a public "hello-world" image (`mcr.microsoft.com/...`) because the ACR is initially empty. 
+- **Image Preservation:** The `infrastructure.yml` workflow is designed to detect if the Container App already exists. If it does, it fetches the current image (e.g., `acrtulspc.azurecr.io/backend:SHA`) and passes it back to Bicep. This prevents infrastructure updates from reverting your app to the "hello-world" placeholder.
 - **Scale-to-Zero:** The backend (Azure Container Apps) is configured with `minReplicas: 0`. It costs $0 when not in use.
 - **Permission Split:** 
     - The `job-spc-dev-migrate` uses a **DDL Identity** (PostgreSQL Admin) for schema changes.

--- a/infrastructure/environment.bicep
+++ b/infrastructure/environment.bicep
@@ -5,8 +5,10 @@ param prefix string = 'spc'
 param env string
 param subnetId string
 param acrName string
+param acrResourceGroup string
 param dbHost string
 param dbName string
+param containerImage string = 'mcr.microsoft.com/azuredigitaltwins/samples/hello-container:latest'
 
 // --- Monitoring (Per Environment) ---
 module monitoring './modules/monitoring.bicep' = {
@@ -27,8 +29,10 @@ module compute './modules/compute.bicep' = {
     env: env
     subnetId: subnetId
     acrName: acrName
+    acrResourceGroup: acrResourceGroup
     dbHost: dbHost
     dbName: dbName
+    containerImage: containerImage
     lawId: monitoring.outputs.workspaceId
     aiConnectionString: monitoring.outputs.connectionString
   }

--- a/infrastructure/environment.bicep
+++ b/infrastructure/environment.bicep
@@ -8,7 +8,7 @@ param acrName string
 param acrResourceGroup string
 param dbHost string
 param dbName string
-param containerImage string = 'mcr.microsoft.com/azuredigitaltwins/samples/hello-container:latest'
+param containerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
 
 // --- Monitoring (Per Environment) ---
 module monitoring './modules/monitoring.bicep' = {

--- a/infrastructure/modules/acr-role.bicep
+++ b/infrastructure/modules/acr-role.bicep
@@ -1,0 +1,17 @@
+param principalId string
+param roleDefinitionId string
+param acrName string
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
+  name: acrName
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, principalId, roleDefinitionId)
+  scope: acr
+  properties: {
+    principalId: principalId
+    roleDefinitionId: roleDefinitionId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -3,15 +3,12 @@ param prefix string
 param env string
 param subnetId string
 param acrName string
+param acrResourceGroup string
 param dbHost string
 param dbName string
 param lawId string
 param aiConnectionString string
-
-// --- ACR Reference ---
-resource acr 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
-  name: acrName
-}
+param containerImage string
 
 var acrPullRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
 
@@ -44,13 +41,13 @@ resource app_identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-
   location: location
 }
 
-resource app_acr_pull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(acr.id, app_identity.id, acrPullRoleDefinitionId)
-  scope: acr
-  properties: {
+module app_acr_pull './acr-role.bicep' = {
+  name: 'app-acr-pull-${env}'
+  scope: resourceGroup(acrResourceGroup)
+  params: {
     principalId: app_identity.properties.principalId
     roleDefinitionId: acrPullRoleDefinitionId
-    principalType: 'ServicePrincipal'
+    acrName: acrName
   }
 }
 
@@ -60,13 +57,13 @@ resource migrator_identity 'Microsoft.ManagedIdentity/userAssignedIdentities@202
   location: location
 }
 
-resource migrator_acr_pull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(acr.id, migrator_identity.id, acrPullRoleDefinitionId)
-  scope: acr
-  properties: {
+module migrator_acr_pull './acr-role.bicep' = {
+  name: 'migrator-acr-pull-${env}'
+  scope: resourceGroup(acrResourceGroup)
+  params: {
     principalId: migrator_identity.properties.principalId
     roleDefinitionId: acrPullRoleDefinitionId
-    principalType: 'ServicePrincipal'
+    acrName: acrName
   }
 }
 
@@ -100,7 +97,7 @@ resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
       containers: [
         {
           name: 'backend'
-          image: '${acrName}.azurecr.io/backend:latest'
+          image: containerImage
           env: [
             { name: 'DATABASE_URL', value: 'postgresql+asyncpg://${app_identity.name}@${dbHost}:5432/${dbName}' }
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: aiConnectionString }
@@ -146,7 +143,7 @@ resource migration_job 'Microsoft.App/jobs@2023-05-01' = {
       containers: [
         {
           name: 'migrator'
-          image: '${acrName}.azurecr.io/backend:latest'
+          image: containerImage
           command: ['alembic', 'upgrade', 'head']
           env: [
             { name: 'DATABASE_URL', value: 'postgresql+asyncpg://${migrator_identity.name}@${dbHost}:5432/${dbName}' }


### PR DESCRIPTION
* ACA cannot be created without the image, but we have no image in the ACR before Backend is built and release, which can only happen after ACA exists. So we use a seed hello-world image instead.
* Additional fixes in documentation and Bicep included.
* Move the creation of resource groups from GH Actions to `README.md` (manual) so that the OIDC service principal can get resource-group scoped access (rather than full subscription).

#115 
