### PR TITLE
Use azure resource listing rather than the deployment group info (deleted after some time)

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Get Shared Outputs
         id: get_acr
         run: |
-          ACR_NAME=$(az deployment group show -g rg-spc-shared-pl -n shared-deployment --query properties.outputs.acrName.value -o tsv)
+          echo "Fetching ACR name from resource group..."
+          ACR_NAME=$(az acr list -g rg-spc-shared-pl --query "[0].name" -o tsv)
           echo "acr_name=$ACR_NAME" >> $GITHUB_OUTPUT
 
       - name: Build and Push Docker image

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -61,9 +61,20 @@ jobs:
       - name: Get Shared Outputs
         id: shared_outputs
         run: |
-          ACR_NAME=$(az deployment group show -g rg-spc-shared-pl -n shared-deployment --query properties.outputs.acrName.value -o tsv)
-          DB_HOST=$(az deployment group show -g rg-spc-shared-pl -n shared-deployment --query properties.outputs.dbHost.value -o tsv)
-          SNET_ID=$(az deployment group show -g rg-spc-shared-pl -n shared-deployment --query properties.outputs.snetDevId.value -o tsv)
+          # Fetch resource identifiers directly from the resource group.
+          # We avoid 'az deployment group show' outputs as they rely on deployment history
+          # which is pruned by Azure and would break workflows when infra isn't redeployed frequently.
+          
+          echo "Fetching ACR name..."
+          ACR_NAME=$(az acr list -g rg-spc-shared-pl --query "[0].name" -o tsv)
+          
+          echo "Fetching Database Host..."
+          DB_HOST=$(az postgres flexible-server list -g rg-spc-shared-pl --query "[0].fullyQualifiedDomainName" -o tsv)
+
+          echo "Fetching Subnet ID for ${{ env.ENV_NAME }}..."
+          SNET_NAME="snet-${{ env.ENV_NAME }}"
+          SNET_ID=$(az network vnet subnet show -g rg-spc-shared-pl --vnet-name vnet-spc-shared -n $SNET_NAME --query id -o tsv)
+
           echo "ACR_NAME=$ACR_NAME" >> $GITHUB_ENV
           echo "DB_HOST=$DB_HOST" >> $GITHUB_ENV
           echo "SNET_ID=$SNET_ID" >> $GITHUB_ENV


### PR DESCRIPTION
This should fix the bug in the BE dev pipeline:  `Run az acr login --name "": ERROR: argument --name/-n: expected one argument`

Contributes to #116 