### PR TITLE
Fix the InvalidAuthorizationSpecificationError: no pg_hba.conf entry error and CORS settings parsing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,13 +6,17 @@
 
 # Application connection URL (DML only — no DDL / schema changes).
 # Used by the FastAPI application at runtime.
-DATABASE_URL=postgresql+asyncpg://tul_psi_app:tul_psi_app@127.0.0.1:5432/student_projects?ssl=disable
+# Example for local development with Docker:
+# DATABASE_URL=postgresql+asyncpg://tul_psi_app:tul_psi_app@127.0.0.1:5432/student_projects
+# To explicitly disable SSL locally:
+# DATABASE_URL=postgresql+asyncpg://tul_psi_app:tul_psi_app@127.0.0.1:5432/student_projects?ssl=disable
+DATABASE_URL=postgresql+asyncpg://tul_psi_app:tul_psi_app@127.0.0.1:5432/student_projects
 
 # Admin connection URL — full DDL+DML access.
 # Used ONLY by Alembic when running schema migrations (e.g. via start.sh or CI/CD).
 # Must match POSTGRES_ADMIN_USER / POSTGRES_ADMIN_PASSWORD in database/.env.
 # Not read by the FastAPI application — see migration_settings.py.
-DATABASE_MIGRATION_URL=postgresql+asyncpg://tul_psi_admin:tul_psi_admin@127.0.0.1:5432/student_projects?ssl=disable
+DATABASE_MIGRATION_URL=postgresql+asyncpg://tul_psi_admin:tul_psi_admin@127.0.0.1:5432/student_projects
 
 # Public base URL of the frontend SPA, included in outgoing email bodies.
 # Override in staging/production to point to the deployed URL (e.g. https://spc.tul.cz).

--- a/backend/db/session.py
+++ b/backend/db/session.py
@@ -36,6 +36,12 @@ def _session_factory() -> async_sessionmaker[AsyncSession]:
             "password": token_provider.get_token,
             "ssl": True,
         }
+    elif settings.app_env != "local":
+        # Force SSL by default in non-local environments if not explicitly disabled.
+        # This prevents "no pg_hba.conf entry ... no encryption" errors when
+        # connecting to cloud databases that require secure transport.
+        if "ssl=disable" not in settings.database_url:
+            engine_kwargs.setdefault("connect_args", {})["ssl"] = True
 
     engine = create_async_engine(
         settings.database_url,

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -26,22 +26,27 @@ class Settings(BaseSettings):
 
     # List of origins allowed to make cross-origin requests (CORS).
     # In production, this should be restricted to the actual frontend domain.
-    allowed_origins: list[str] = ["http://localhost:3000", "http://127.0.0.1:3000"]
+    allowed_origins: list[str] | str = ["http://localhost:3000", "http://127.0.0.1:3000"]
 
     @field_validator("allowed_origins", mode="before")
     @classmethod
-    def assemble_cors_origins(cls, v: str | list[str]) -> str | list[str]:
+    def assemble_cors_origins(cls, v: str | list[str]) -> list[str]:
         """Support comma-separated strings or JSON lists for CORS origins."""
         if isinstance(v, str):
             if v.startswith("[") and v.endswith("]"):
                 import json
 
                 try:
-                    return json.loads(v)
-                except json.JSONDecodeError:
+                    result = json.loads(v)
+                    if isinstance(result, list):
+                        return result
+                except (json.JSONDecodeError, TypeError):
                     pass
-            return [i.strip() for i in v.split(",")]
-        return v
+            # Handle empty string or comma-separated string
+            if not v:
+                return []
+            return [i.strip() for i in v.split(",") if i.strip()]
+        return v if isinstance(v, list) else [v]
 
     # Secret key used to sign JWT session cookies.
     # Must be a long, random string; override in production via the JWT_SECRET env var.


### PR DESCRIPTION
Fixes 2 errors:
* SettingsError because Pydantic tried to parse the field as JSON array (list[str])
* SSL Connection ("no encryption"): Azure Database for PostgreSQL requires SSL by default. While Bicep file sets `AZURE_MANAGED_IDENTITY_ENABLED=true`, the `InvalidAuthorizationSpecificationError: no pg_hba.conf entry for host \"10.0.1.196\"` indicates that the asyncpg driver was still attempting a non-encrypted connection 

Contributes to #150 