### PR TITLE
Fix backend deployment - pass the container name to backend, fix settings for migrator and improve versioning

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -37,7 +37,15 @@ jobs:
       - name: Build and Push Docker image
         run: |
           az acr login --name ${{ steps.get_acr.outputs.acr_name }}
-          docker build -t ${{ steps.get_acr.outputs.acr_name }}.azurecr.io/backend:${{ github.sha }} -t ${{ steps.get_acr.outputs.acr_name }}.azurecr.io/backend:latest ./backend
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          # Format: [BaseVersion]-b[RunNumber]+[ShortSHA] (e.g., 0.1.0-b42+a1b2c3d)
+          VERSION="0.1.0-b${{ github.run_number }}+${SHORT_SHA}"
+          echo "Building version: $VERSION"
+          docker build \
+            --build-arg APP_VERSION=$VERSION \
+            -t ${{ steps.get_acr.outputs.acr_name }}.azurecr.io/backend:${{ github.sha }} \
+            -t ${{ steps.get_acr.outputs.acr_name }}.azurecr.io/backend:latest \
+            ./backend
           docker push ${{ steps.get_acr.outputs.acr_name }}.azurecr.io/backend:${{ github.sha }}
           docker push ${{ steps.get_acr.outputs.acr_name }}.azurecr.io/backend:latest
 

--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -52,12 +52,18 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Update Migrations Job Image
+        run: |
+          az containerapp job update \
+            --name job-spc-dev-migrate \
+            --resource-group rg-spc-dev-pl \
+            --image ${{ needs.build-and-push.outputs.acr_name }}.azurecr.io/backend:${{ github.sha }}
+
       - name: Run Migrations Job
         run: |
           az containerapp job start \
             --name job-spc-dev-migrate \
-            --resource-group rg-spc-dev-pl \
-            --image ${{ needs.build-and-push.outputs.acr_name }}.azurecr.io/backend:${{ github.sha }}
+            --resource-group rg-spc-dev-pl
 
       - name: Update Backend App
         run: |
@@ -65,5 +71,6 @@ jobs:
           az containerapp update \
             --name ca-spc-dev-backend \
             --resource-group rg-spc-dev-pl \
+            --container-name backend \
             --image ${{ needs.build-and-push.outputs.acr_name }}.azurecr.io/backend:${{ github.sha }} \
             --set-env-vars FRONTEND_URL=https://$FRONTEND_URL

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -81,7 +81,7 @@ jobs:
           
           # Try to get the current image to avoid reverting to hello-world
           # If the app doesn't exist yet, it will use the Bicep default
-          CURRENT_IMAGE=$(az containerapp show -n ca-spc-${{ env.ENV_NAME }}-backend -g rg-spc-${{ env.ENV_NAME }}-pl --query "properties.template.containers[0].image" -o tsv 2>/dev/null || echo "")
+          CURRENT_IMAGE=$(az containerapp show -n ca-spc-${{ env.ENV_NAME }}-backend -g rg-spc-${{ env.ENV_NAME }}-pl --query "properties.template.containers[?name=='backend'].image" -o tsv 2>/dev/null || echo "")
           echo "CURRENT_IMAGE=$CURRENT_IMAGE" >> $GITHUB_ENV
 
       - name: Deploy Env Bicep

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,9 +31,9 @@ RUN pip install --no-cache-dir --no-index --find-links=/wheels -r requirements.t
 # Copy application code
 COPY . .
 
-# Install the project itself so importlib.metadata.version() resolves its version at runtime.
-# Dependencies are already installed from wheels.
-RUN pip install --no-cache-dir --no-deps .
+# Set application version from build arg
+ARG APP_VERSION
+ENV APP_VERSION=$APP_VERSION
 
 # Ensure the app is owned by appuser
 RUN chown -R appuser:appuser /app

--- a/backend/api/health.py
+++ b/backend/api/health.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import logging
-from importlib.metadata import PackageNotFoundError, version
-
 import httpx
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
@@ -11,13 +9,9 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.session import get_session
+from settings import Settings, get_settings
 
 logger = logging.getLogger(__name__)
-
-try:
-    _APP_VERSION: str = version("student-projects-catalogue-backend")
-except PackageNotFoundError:
-    _APP_VERSION = "0.0.0"
 
 router = APIRouter(tags=["health"])
 
@@ -85,6 +79,7 @@ async def _check_otel_collector() -> ComponentCheck:
 )
 async def health(
     session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
 ) -> JSONResponse:
     """Perform health checks and return standardized response."""
     db_check = await _check_database(session)
@@ -103,8 +98,8 @@ async def health(
 
     content = HealthResponse(
         status=overall_status,
-        version=_APP_VERSION,
-        releaseId=_APP_VERSION,
+        version=settings.app_version,
+        releaseId=settings.app_version,
         checks={
             "postgresql:connection": [db_check],
             "otel:collector": [otel_check],

--- a/backend/api/health.py
+++ b/backend/api/health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+
 import httpx
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
 
     app_name: str = "student-projects-catalogue-backend"
     app_env: str = "local"
+    app_version: str = "0.0.0-local"
 
     # Application connection URL (DML only — no DDL / schema changes).
     # Used by the FastAPI application at runtime.

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -19,7 +19,11 @@ class Settings(BaseSettings):
 
     # Application connection URL (DML only — no DDL / schema changes).
     # Used by the FastAPI application at runtime.
-    database_url: str
+    database_url: str | None = None
+
+    # Migration connection URL (DDL — high privilege).
+    # Used only by the Alembic migration job.
+    database_migration_url: str | None = None
 
     # Public base URL of the frontend SPA (e.g. https://spc.tul.cz in production).
     # Included in outgoing email bodies so recipients can navigate to the portal.
@@ -59,13 +63,15 @@ class Settings(BaseSettings):
     azure_managed_identity_enabled: bool = False
 
     @model_validator(mode="after")
-    def _check_insecure_defaults_in_production(self) -> Settings:
-        """Raise at startup when the JWT secret placeholder is used in production.
+    def _validate_settings(self) -> Settings:
+        """Validate critical configuration after loading from environment."""
+        # 1. Ensure at least one database connection URL is provided.
+        if not self.database_url and not self.database_migration_url:
+            raise ValueError(
+                "At least one of DATABASE_URL or DATABASE_MIGRATION_URL must be provided."
+            )
 
-        This prevents a misconfigured deployment from silently accepting forged
-        session cookies — all tokens would be forgeable with the well-known default.
-        Override ``JWT_SECRET`` via the environment variable in non-local deployments.
-        """
+        # 2. Raise at startup when the JWT secret placeholder is used in production.
         if self.app_env != "local" and self.jwt_secret == _JWT_SECRET_PLACEHOLDER:
             raise ValueError(
                 f"JWT_SECRET must be overridden in the '{self.app_env}' environment. "

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -179,6 +179,8 @@ resource migration_job 'Microsoft.App/jobs@2023-05-01' = {
           env: [
             { name: 'DATABASE_MIGRATION_URL', value: 'postgresql+asyncpg://${dbHost}:5432/${dbName}' }
             { name: 'AZURE_MANAGED_IDENTITY_ENABLED', value: 'true' }
+            { name: 'APP_ENV', value: env }
+            { name: 'JWT_SECRET', value: jwtSecret }
           ]
         }
       ]

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -118,10 +118,8 @@ resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
         {
           name: 'otel-collector'
           image: 'otel/opentelemetry-collector-contrib:0.111.0'
-          command: [
-            'sh'
-            '-c'
-            'mkdir -p /tmp/otelcol && echo "$OTEL_CONFIG_CONTENT" > /tmp/otelcol/config.yaml && /otelcol-contrib --config /tmp/otelcol/config.yaml'
+          args: [
+            '--config=env:OTEL_CONFIG_CONTENT'
           ]
           env: [
             {

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -101,7 +101,7 @@ resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
           name: 'backend'
           image: containerImage
           env: [
-            { name: 'DATABASE_URL', value: 'postgresql+asyncpg://${app_identity.name}@${dbHost}:5432/${dbName}' }
+            { name: 'DATABASE_URL', value: 'postgresql+asyncpg://${dbHost}:5432/${dbName}' }
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: aiConnectionString }
             { name: 'JWT_SECRET', value: jwtSecret }
             { name: 'APP_ENV', value: env }
@@ -177,7 +177,7 @@ resource migration_job 'Microsoft.App/jobs@2023-05-01' = {
           image: containerImage
           command: ['alembic', 'upgrade', 'head']
           env: [
-            { name: 'DATABASE_MIGRATION_URL', value: 'postgresql+asyncpg://${migrator_identity.name}@${dbHost}:5432/${dbName}' }
+            { name: 'DATABASE_MIGRATION_URL', value: 'postgresql+asyncpg://${dbHost}:5432/${dbName}' }
             { name: 'AZURE_MANAGED_IDENTITY_ENABLED', value: 'true' }
           ]
         }


### PR DESCRIPTION
  🚀 CI/CD & Deployment Fixes
   * Backend Deployment: Fixed az containerapp update failures by explicitly targeting the --container-name backend. This was
     required after the addition of the OTel sidecar.
   * Migration Job: Corrected the deployment flow to use az containerapp job update before start, ensuring the latest image is
     always used for migrations.
   * Robust Infra Queries: Updated infrastructure.yml to fetch the current image by container name (backend) rather than index,
     preventing deployment loops when sidecars are present.

  🔐 Database & Identity
   * Managed Identity Fix: Removed the hardcoded username from DATABASE_URL and DATABASE_MIGRATION_URL in Bicep. This resolves  the InvalidAuthorizationSpecificationError by allowing asyncpg to correctly use Entra ID tokens without credential     conflicts.
   * Migrator Environment: Added APP_ENV and JWT_SECRET to the Migration Job to ensure consistent settings validation across all     processes.

  📊 Observability & Sidecars
   * OTel Collector Fix: Resolved a startup failure in the otel-collector sidecar. Switched from a shell-based command (which  failed on the distroless image) to the native OTel env: configuration provider.

  🛠️ Backend Refactoring & Versioning
   * Simplified Versioning: Replaced the complex pyproject.toml patching with a cleaner APP_VERSION environment variable. 
   * Sequential Traceability: Updated the build process to generate a human-readable and traceable version string:
     [BaseVersion]-b[RunNumber]+[ShortSHA] (e.g., 0.1.0-b42+a1b2c3d).
   * Flexible Settings: Refactored Settings to allow the application to boot with either DATABASE_URL or DATABASE_MIGRATION_URL,     resolving "field required" errors during migrations where only the privileged URL is provided.
   * Health API: Enhanced the /health endpoint to report the dynamic version and release ID directly from the environment.

Contributes to #150 