### PR TITLE
Provide the value of the user assigned identity to the DefaultAzureCredential

### DIFF
--- a/backend/db/token_provider.py
+++ b/backend/db/token_provider.py
@@ -9,7 +9,15 @@ class TokenProvider:
     def __init__(self) -> None:
         from azure.identity.aio import DefaultAzureCredential
 
-        self.credential = DefaultAzureCredential()
+        from settings import get_settings
+
+        settings = get_settings()
+
+        # For User Assigned Managed Identity, we MUST provide the client ID.
+        # If it is None, DefaultAzureCredential will try System Assigned identity.
+        self.credential = DefaultAzureCredential(
+            managed_identity_client_id=settings.azure_client_id
+        )
         self._token: Any = None
 
     async def get_token(self) -> str:

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -61,6 +61,7 @@ class Settings(BaseSettings):
 
     # Support for Entra ID (Azure Managed Identity) for DB authentication.
     azure_managed_identity_enabled: bool = False
+    azure_client_id: str | None = None
 
     # Health check URL for the OTel collector sidecar/service.
     # In Azure, it's typically http://localhost:13133.

--- a/backend/tests/db/test_managed_identity.py
+++ b/backend/tests/db/test_managed_identity.py
@@ -11,6 +11,25 @@ from settings import Settings
 
 
 @pytest.mark.asyncio
+async def test_token_provider_uses_client_id_from_settings():
+    """Verify that TokenProvider passes azure_client_id to DefaultAzureCredential."""
+    mock_settings = Settings(
+        database_url="postgresql+asyncpg://localhost/test",
+        azure_client_id="test-client-id",
+        jwt_secret="dummy-secret-for-testing-only-12345",  # noqa: S106
+    )
+
+    with (
+        patch("settings.get_settings", return_value=mock_settings),
+        patch("azure.identity.aio.DefaultAzureCredential") as mock_credential_class,
+    ):
+        TokenProvider()
+
+        # Check that DefaultAzureCredential was instantiated with the correct client ID
+        mock_credential_class.assert_called_once_with(managed_identity_client_id="test-client-id")
+
+
+@pytest.mark.asyncio
 async def test_token_provider_returns_token():
     """Verify that TokenProvider calls DefaultAzureCredential with the correct scope."""
     mock_token = MagicMock()

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -108,6 +108,7 @@ resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
             { name: 'ALLOWED_ORIGINS', value: 'https://${frontend_swa.properties.defaultHostname}' }
             { name: 'FRONTEND_URL', value: 'https://${frontend_swa.properties.defaultHostname}' }
             { name: 'AZURE_MANAGED_IDENTITY_ENABLED', value: 'true' }
+            { name: 'AZURE_CLIENT_ID', value: app_identity.properties.clientId }
             { name: 'OTEL_EXPORTER_OTLP_ENDPOINT', value: 'http://localhost:4318' }
           ]
           resources: {
@@ -177,6 +178,7 @@ resource migration_job 'Microsoft.App/jobs@2023-05-01' = {
           env: [
             { name: 'DATABASE_MIGRATION_URL', value: 'postgresql+asyncpg://${dbHost}:5432/${dbName}' }
             { name: 'AZURE_MANAGED_IDENTITY_ENABLED', value: 'true' }
+            { name: 'AZURE_CLIENT_ID', value: migrator_identity.properties.clientId }
             { name: 'APP_ENV', value: env }
             { name: 'JWT_SECRET', value: jwtSecret }
           ]


### PR DESCRIPTION
Otherwise it can't figure out which one to use and doesn't use any...

Contributes to #150 