### PR TITLE
Provide the user managed identity name in the DB connection string

### DIFF
--- a/backend/migration_settings.py
+++ b/backend/migration_settings.py
@@ -23,6 +23,7 @@ class MigrationSettings(BaseSettings):
 
     # Support for Entra ID (Azure Managed Identity) for DB authentication.
     azure_managed_identity_enabled: bool = False
+    azure_client_id: str | None = None
 
 
 @lru_cache

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -101,7 +101,7 @@ resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
           name: 'backend'
           image: containerImage
           env: [
-            { name: 'DATABASE_URL', value: 'postgresql+asyncpg://${dbHost}:5432/${dbName}' }
+            { name: 'DATABASE_URL', value: 'postgresql+asyncpg://${app_identity.name}@${dbHost}:5432/${dbName}' }
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: aiConnectionString }
             { name: 'JWT_SECRET', value: jwtSecret }
             { name: 'APP_ENV', value: env }
@@ -176,7 +176,7 @@ resource migration_job 'Microsoft.App/jobs@2023-05-01' = {
           image: containerImage
           command: ['alembic', 'upgrade', 'head']
           env: [
-            { name: 'DATABASE_MIGRATION_URL', value: 'postgresql+asyncpg://${dbHost}:5432/${dbName}' }
+            { name: 'DATABASE_MIGRATION_URL', value: 'postgresql+asyncpg://${migrator_identity.name}@${dbHost}:5432/${dbName}' }
             { name: 'AZURE_MANAGED_IDENTITY_ENABLED', value: 'true' }
             { name: 'AZURE_CLIENT_ID', value: migrator_identity.properties.clientId }
             { name: 'APP_ENV', value: env }

--- a/infrastructure/monitoring/otel-collector-config.azure.yaml
+++ b/infrastructure/monitoring/otel-collector-config.azure.yaml
@@ -11,14 +11,12 @@ receivers:
 processors:
   batch:
   resourcedetection:
-    detectors: [env]
+    detectors: [env, azure]
 
 exporters:
-  # Traces/Logs/Metrics for Azure Monitor
   azuremonitor:
     connection_string: "${env:APPLICATIONINSIGHTS_CONNECTION_STRING}"
 
-  # Keep debug for container logs visibility
   debug:
     verbosity: basic
 


### PR DESCRIPTION
Hoping to fix a bug which makes the app try to use the `appuser` when connecting to DB - now forcing it to the UAMI name.

Contributes to #150 