### PR TITLE
Move the DB bootstrap into dev environment and enabled system managed identity for Postgres

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -75,9 +75,21 @@ jobs:
           SNET_NAME="snet-${{ env.ENV_NAME }}"
           SNET_ID=$(az network vnet subnet show -g rg-spc-shared-pl --vnet-name vnet-spc-shared -n $SNET_NAME --query id -o tsv)
 
+          echo "Fetching Shared DB Bootstrap outputs..."
+          # We use az deployment group show to get outputs from the shared deployment
+          SHARED_OUTPUTS=$(az deployment group show -g rg-spc-shared-pl -n shared-deployment --query properties.outputs)
+          ID_DB_SETUP_ID=$(echo $SHARED_OUTPUTS | jq -r .idDbSetupId.value)
+          ID_DB_SETUP_NAME=$(echo $SHARED_OUTPUTS | jq -r .idDbSetupName.value)
+          STORAGE_ACCOUNT_NAME=$(echo $SHARED_OUTPUTS | jq -r .storageAccountName.value)
+          SCRIPTS_SNET_ID=$(echo $SHARED_OUTPUTS | jq -r .snetScriptsId.value)
+
           echo "ACR_NAME=$ACR_NAME" >> $GITHUB_ENV
           echo "DB_HOST=$DB_HOST" >> $GITHUB_ENV
           echo "SNET_ID=$SNET_ID" >> $GITHUB_ENV
+          echo "ID_DB_SETUP_ID=$ID_DB_SETUP_ID" >> $GITHUB_ENV
+          echo "ID_DB_SETUP_NAME=$ID_DB_SETUP_NAME" >> $GITHUB_ENV
+          echo "STORAGE_ACCOUNT_NAME=$STORAGE_ACCOUNT_NAME" >> $GITHUB_ENV
+          echo "SCRIPTS_SNET_ID=$SCRIPTS_SNET_ID" >> $GITHUB_ENV
           
           # Try to get the current image to avoid reverting to hello-world
           # If the app doesn't exist yet, it will use the Bicep default
@@ -98,5 +110,9 @@ jobs:
             acrResourceGroup=rg-spc-shared-pl
             dbHost=${{ env.DB_HOST }}
             dbName=spc_${{ env.ENV_NAME }}
+            idDbSetupId=${{ env.ID_DB_SETUP_ID }}
+            idDbSetupName=${{ env.ID_DB_SETUP_NAME }}
+            storageAccountName=${{ env.STORAGE_ACCOUNT_NAME }}
+            scriptsSubnetId=${{ env.SCRIPTS_SNET_ID }}
             jwtSecret=${{ secrets.JWT_SECRET }}
             ${{ env.CURRENT_IMAGE != '' && format('containerImage={0}', env.CURRENT_IMAGE) || '' }}

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -64,34 +64,35 @@ for rg in "rg-spc-shared-pl" "rg-spc-dev-pl" "rg-spc-prod-pl"; do
 done
 ```
 
-### Step 2: Create DB Bootstrap Identity (Required for VNet DB Access)
-Because the DB is in a VNet, Bicep uses a temporary script to create roles. This identity needs "Directory Readers" to look up other Managed Identities.
+### Step 2: Create DB Bootstrap Identity & Grant Permissions (Required for VNet DB Access)
+Because the DB is in a VNet, Bicep uses a temporary script to create roles. This identity and the DB server itself need permissions to look up other Managed Identities in Entra ID.
 
 ```bash
 # 1. Create the identity in the 'shared' resource group
 az identity create -g rg-spc-shared-pl -n id-spc-shared-db-setup
 
-# 2. Get its ID
+# 2. Get the Principal IDs for both the Setup Identity and the DB Server
 SETUP_PRINCIPAL_ID=$(az identity show -g rg-spc-shared-pl -n id-spc-shared-db-setup --query principalId -o tsv)
+DB_SERVER_PRINCIPAL_ID=$(az postgres flexible-server show -g rg-spc-shared-pl -n psql-spc-shared --query identity.principalId -o tsv)
 
-# 3. Assign Granular Graph Permissions (Least Privilege)
-# These allow the identity to read Entra ID metadata during DB setup.
+# 3. Define the Granular Graph Permissions (Least Privilege)
 GRAPH_ID=$(az ad sp list --filter "displayName eq 'Microsoft Graph'" --query '[0].id' -o tsv)
-
-# 4. Query and assign User.Read.All, GroupMember.Read.All & Application.Read.All to my identity in MS Graph.
 APPROLE_IDS=$(az ad sp show --id "$GRAPH_ID" \
   --query "appRoles[?value=='User.Read.All' || value=='GroupMember.Read.All' || value=='Application.Read.All'].id" \
   -o tsv)
 
-# Loop through each AppRole ID and assign it
-for ROLE_ID in $APPROLE_IDS; do
-  az rest --method POST \
-    --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$SETUP_PRINCIPAL_ID/appRoleAssignments" \
-    --body "{
-      \"principalId\": \"$SETUP_PRINCIPAL_ID\",
-      \"resourceId\": \"$GRAPH_ID\",
-      \"appRoleId\": \"$ROLE_ID\"
-    }"
+# 4. Assign permissions to both identities
+for PRINCIPAL_ID in $SETUP_PRINCIPAL_ID $DB_SERVER_PRINCIPAL_ID; do
+  echo "Assigning permissions to Principal: $PRINCIPAL_ID"
+  for ROLE_ID in $APPROLE_IDS; do
+    az rest --method POST \
+      --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$PRINCIPAL_ID/appRoleAssignments" \
+      --body "{
+        \"principalId\": \"$PRINCIPAL_ID\",
+        \"resourceId\": \"$GRAPH_ID\",
+        \"appRoleId\": \"$ROLE_ID\"
+      }"
+  done
 done
 ```
 
@@ -170,6 +171,10 @@ az deployment group validate \
                acrResourceGroup="rg-spc-shared-pl" \
                dbHost="psql-spc-shared.postgres.database.azure.com" \
                dbName="spc_dev" \
+               idDbSetupId="/subscriptions/ca830bff-0330-40f0-8d49-a18d5db67e9c/resourceGroups/rg-spc-shared-pl/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-spc-shared-db-setup" \
+               idDbSetupName="id-spc-shared-db-setup" \
+               storageAccountName="stspcsharedscripts" \
+               scriptsSubnetId="/subscriptions/ca830bff-0330-40f0-8d49-a18d5db67e9c/resourceGroups/rg-spc-shared-pl/providers/Microsoft.Network/virtualNetworks/vnet-spc-shared/subnets/snet-scripts" \
                jwtSecret="not-a-secret-just-for-validation-purposes"
 ```
 

--- a/infrastructure/environment.bicep
+++ b/infrastructure/environment.bicep
@@ -8,6 +8,10 @@ param acrName string
 param acrResourceGroup string
 param dbHost string
 param dbName string
+param idDbSetupId string
+param idDbSetupName string
+param storageAccountName string
+param scriptsSubnetId string
 param containerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
 @secure()
 param jwtSecret string
@@ -39,6 +43,25 @@ module compute './modules/compute.bicep' = {
     lawId: monitoring.outputs.workspaceId
     aiConnectionString: monitoring.outputs.connectionString
   }
+}
+
+// --- Database Role Bootstrap ---
+module dbBootstrap './modules/database-bootstrap.bicep' = {
+  name: 'db-bootstrap-${env}-deployment'
+  params: {
+    location: location
+    prefix: prefix
+    env: env
+    dbHost: dbHost
+    dbName: dbName
+    idDbSetupId: idDbSetupId
+    dbAdminName: idDbSetupName
+    storageAccountName: storageAccountName
+    scriptsSubnetId: scriptsSubnetId
+  }
+  dependsOn: [
+    compute
+  ]
 }
 
 output backendUrl string = compute.outputs.backendUrl

--- a/infrastructure/modules/database-bootstrap.bicep
+++ b/infrastructure/modules/database-bootstrap.bicep
@@ -1,0 +1,103 @@
+param location string
+param prefix string
+param env string
+param scriptsSubnetId string
+param storageAccountName string
+param dbHost string
+param dbAdminName string
+param dbName string
+param idDbSetupId string
+
+// --- Deployment Script (The "Ad-hoc Setup Job") ---
+// This resource executes SQL commands inside the VNet using the Setup Identity.
+resource dbBootstrap 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: 'ds-${prefix}-${env}-bootstrap'
+  location: location
+  kind: 'AzureCLI'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${idDbSetupId}': {}
+    }
+  }
+  properties: {
+    azCliVersion: '2.50.0'
+    containerSettings: {
+      containerGroupName: 'cg-${prefix}-${env}-db-bootstrap'
+      subnetIds: [
+        {
+          id: scriptsSubnetId
+        }
+      ]
+    }
+    storageAccountSettings: {
+      storageAccountName: storageAccountName
+    }
+    environmentVariables: [
+      { name: 'DB_HOST', value: dbHost }
+      { name: 'DB_ADMIN', value: dbAdminName }
+      { name: 'DB_NAME', value: dbName }
+      { name: 'ENV', value: env }
+    ]
+    scriptContent: '''
+      set -e
+      echo "Waiting for DNS to propagate..."
+      sleep 30
+      
+      # Install psql (alpine-based azure-cli container needs it)
+      apk update && apk add postgresql-client
+      
+      # Get token for PostgreSQL Entra ID authentication
+      export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv)
+      
+      echo "Bootstrapping $DB_NAME for $ENV..."
+      psql "host=${DB_HOST} user=${DB_ADMIN} dbname=${DB_NAME} sslmode=require" <<EOF
+        -- 1. Create Roles for Managed Identities
+        -- Note: pgaadauth_create_principal is a custom Azure PG extension function
+        DO \$$
+        BEGIN
+          IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'id-spc-${ENV}-migrator') THEN
+            PERFORM pgaadauth_create_principal('id-spc-${ENV}-migrator', false, false);
+          END IF;
+          IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'id-spc-${ENV}-app') THEN
+            PERFORM pgaadauth_create_principal('id-spc-${ENV}-app', false, false);
+          END IF;
+        END \$$;
+
+        -- 2. Grant Permissions
+        -- The migrator needs to manage schema (DDL)
+        ALTER SCHEMA public OWNER TO "id-spc-${ENV}-migrator";
+        GRANT ALL PRIVILEGES ON DATABASE ${DB_NAME} TO "id-spc-${ENV}-migrator";
+        
+        -- The app needs to manage data (DML)
+        GRANT CONNECT ON DATABASE ${DB_NAME} TO "id-spc-${ENV}-app";
+        GRANT USAGE ON SCHEMA public TO "id-spc-${ENV}-app";
+        
+        -- Automatically grant permissions on tables created by the migrator in the future
+        ALTER DEFAULT PRIVILEGES FOR ROLE "id-spc-${ENV}-migrator" IN SCHEMA public 
+        GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "id-spc-${ENV}-app";
+        
+        ALTER DEFAULT PRIVILEGES FOR ROLE "id-spc-${ENV}-migrator" IN SCHEMA public 
+        GRANT USAGE, SELECT ON SEQUENCES TO "id-spc-${ENV}-app";
+EOF
+
+      echo "Verifying that Managed Identity roles were created..."
+      MISSING_ROLES=$(psql "host=${DB_HOST} user=${DB_ADMIN} dbname=${DB_NAME} sslmode=require" -t -A <<EOF
+        SELECT rolname FROM (VALUES ('id-spc-${ENV}-migrator'), ('id-spc-${ENV}-app')) AS t(rolname)
+        EXCEPT
+        SELECT rolname FROM pg_roles;
+EOF
+)
+
+      if [ -n "$MISSING_ROLES" ]; then
+        echo "ERROR: The following Managed Identity roles are missing from the database: $MISSING_ROLES"
+        echo "Verify that the PostgreSQL Server identity has 'Directory Readers' (or equivalent) Graph permissions."
+        exit 1
+      fi
+
+      echo "SUCCESS: Database bootstrap and role verification complete for $ENV."
+    '''
+    retentionInterval: 'P1D'
+    cleanupPreference: 'OnSuccess'
+  }
+}

--- a/infrastructure/modules/database.bicep
+++ b/infrastructure/modules/database.bicep
@@ -74,6 +74,9 @@ resource filePrivilegedContributor 'Microsoft.Authorization/roleAssignments@2022
 resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-06-01-preview' = {
   name: 'psql-${prefix}-${env}'
   location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
   sku: {
     name: 'Standard_B1ms'
     tier: 'Burstable'
@@ -135,95 +138,8 @@ module postgresAdmin './database-admin.bicep' = {
   }
 }
 
-// --- Deployment Script (The "Ad-hoc Setup Job") ---
-// This resource executes SQL commands inside the VNet using the Setup Identity.
-resource dbBootstrap 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
-  name: 'ds-${prefix}-${env}-bootstrap'
-  location: location
-  kind: 'AzureCLI'
-  identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: {
-      '${idDbSetup.id}': {}
-    }
-  }
-  dependsOn: [
-    postgresAdmin
-    db_dev
-    storageContributor
-    blobContributor
-    filePrivilegedContributor
-  ]
-  properties: {
-    azCliVersion: '2.50.0'
-    containerSettings: {
-      containerGroupName: 'cg-${prefix}-${env}-db-bootstrap'
-      subnetIds: [
-        {
-          id: scriptsSubnetId
-        }
-      ]
-    }
-    storageAccountSettings: {
-      storageAccountName: storageAccount.name
-    }
-    environmentVariables: [
-      { name: 'DB_HOST', value: postgres.properties.fullyQualifiedDomainName }
-      { name: 'DB_ADMIN', value: idDbSetup.name }
-    ]
-    scriptContent: '''
-      echo "Waiting for DNS to propagate..."
-      sleep 30
-      
-      # Install psql (alpine-based azure-cli container needs it)
-      apk update && apk add postgresql-client
-      
-      # Get token for PostgreSQL Entra ID authentication
-      export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv)
-      
-      bootstrap_db() {
-        local dbname=$1
-        local environment=$2
-        echo "Bootstrapping $dbname for $environment..."
-        psql "host=${DB_HOST} user=${DB_ADMIN} dbname=${dbname} sslmode=require" <<EOF
-          -- 1. Create Roles for Managed Identities
-          -- Note: pgaadauth_create_principal is a custom Azure PG extension function
-          DO \$$
-          BEGIN
-            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'id-spc-${environment}-migrator') THEN
-              PERFORM pgaadauth_create_principal('id-spc-${environment}-migrator', false, false);
-            END IF;
-            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'id-spc-${environment}-app') THEN
-              PERFORM pgaadauth_create_principal('id-spc-${environment}-app', false, false);
-            END IF;
-          END \$$;
-
-
-          -- 2. Grant Permissions
-          -- The migrator needs to manage schema (DDL)
-          ALTER SCHEMA public OWNER TO "id-spc-${environment}-migrator";
-          GRANT ALL PRIVILEGES ON DATABASE ${dbname} TO "id-spc-${environment}-migrator";
-          
-          -- The app needs to manage data (DML)
-          GRANT CONNECT ON DATABASE ${dbname} TO "id-spc-${environment}-app";
-          GRANT USAGE ON SCHEMA public TO "id-spc-${environment}-app";
-          
-          -- Automatically grant permissions on tables created by the migrator in the future
-          ALTER DEFAULT PRIVILEGES FOR ROLE "id-spc-${environment}-migrator" IN SCHEMA public 
-          GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "id-spc-${environment}-app";
-          
-          ALTER DEFAULT PRIVILEGES FOR ROLE "id-spc-${environment}-migrator" IN SCHEMA public 
-          GRANT USAGE, SELECT ON SEQUENCES TO "id-spc-${environment}-app";
-EOF
-      }
-
-      # Currently only bootstrapping the 'dev' environment roles
-      bootstrap_db "spc_dev" "dev"
-    '''
-    retentionInterval: 'P1D'
-    cleanupPreference: 'OnSuccess'
-  }
-}
-
 output postgresId string = postgres.id
 output postgresFullyQualifiedDomainName string = postgres.properties.fullyQualifiedDomainName
+output idDbSetupId string = idDbSetup.id
+output idDbSetupName string = idDbSetup.name
+output storageAccountName string = storageAccount.name

--- a/infrastructure/shared.bicep
+++ b/infrastructure/shared.bicep
@@ -48,3 +48,7 @@ output vnetId string = network.outputs.vnetId
 output snetDevId string = network.outputs.snetDevId
 output snetProdId string = network.outputs.snetProdId
 output dbHost string = database.outputs.postgresFullyQualifiedDomainName
+output idDbSetupId string = database.outputs.idDbSetupId
+output idDbSetupName string = database.outputs.idDbSetupName
+output storageAccountName string = database.outputs.storageAccountName
+output snetScriptsId string = network.outputs.snetScriptsId


### PR DESCRIPTION
This shoudl fix the "password authentication failed" error - Postgres was falling back to it because it didn't have System MI enabled and couldn't talk to the Entra directory server to validate the identity of the caller.

**Changes**:
* Infrastructure (Bicep):
     * Enabled System-Assigned Identity on the PostgreSQL Flexible Server to allow Entra ID
         principal verification.
     * Decoupled database bootstrapping into a per-environment module (database-bootstrap.bicep) to
         ensure environment identities exist before they are mapped to DB roles.
     * Added an explicit verification step to the bootstrap script to confirm role creation and
         provide clear error messages for Graph permission issues.
     * Created an Azure-optimized OpenTelemetry Collector configuration to restore telemetry flow
         to Application Insights.
 * Backend:
     * Updated Settings and MigrationSettings to support explicit AZURE_CLIENT_ID for User-Assigned
         Managed Identity resolution.
     * Explicitly included the identity name as the username in database connection strings (e.g.,
         id-spc-dev-app@...) to satisfy asyncpg/Azure requirements.
     * Refactored /health to be RFC-compliant (application/health+json) with deep probes for DB and
         OTel sidecar health.
 * Workflow & Documentation:
     * Updated .github/workflows/infrastructure.yml to orchestrate new bootstrap parameters.
     * Consolidated the README.md setup instructions to include mandatory Graph API permissions for
         both the bootstrap and database server identities.


Contributes to #150 