### PR TITLE
Create pgadmin ACA container in dev environment to enable debugging and fix the seed script execution place

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -67,11 +67,27 @@ jobs:
             --resource-group rg-spc-dev-pl \
             --image ${{ needs.build-and-push.outputs.acr_name }}.azurecr.io/backend:${{ github.sha }}
 
-      - name: Run Migrations Job
+      - name: Run Migrations and Seed
         run: |
-          az containerapp job start \
+          EXECUTION_NAME=$(az containerapp job start \
             --name job-spc-dev-migrate \
-            --resource-group rg-spc-dev-pl
+            --resource-group rg-spc-dev-pl \
+            --query name -o tsv)
+          echo "Started execution: $EXECUTION_NAME"
+          for i in $(seq 1 36); do
+            STATUS=$(az containerapp job execution show \
+              --name job-spc-dev-migrate \
+              --resource-group rg-spc-dev-pl \
+              --job-execution-name "$EXECUTION_NAME" \
+              --query "properties.status" -o tsv)
+            echo "Status [$i/36]: $STATUS"
+            case "$STATUS" in
+              Succeeded) echo "Job completed successfully."; break ;;
+              Failed|Stopped) echo "Job failed: $STATUS"; exit 1 ;;
+            esac
+            sleep 10
+          done
+          [[ "$STATUS" == "Succeeded" ]] || { echo "Timed out waiting for job."; exit 1; }
 
       - name: Update Backend App
         run: |

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -114,5 +114,6 @@ jobs:
             idDbSetupName=${{ env.ID_DB_SETUP_NAME }}
             storageAccountName=${{ env.STORAGE_ACCOUNT_NAME }}
             scriptsSubnetId=${{ env.SCRIPTS_SNET_ID }}
+            deployDebugTools=${{ env.ENV_NAME == 'dev' }}
             jwtSecret=${{ secrets.JWT_SECRET }}
             ${{ env.CURRENT_IMAGE != '' && format('containerImage={0}', env.CURRENT_IMAGE) || '' }}

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -116,4 +116,6 @@ jobs:
             scriptsSubnetId=${{ env.SCRIPTS_SNET_ID }}
             deployDebugTools=${{ env.ENV_NAME == 'dev' }}
             jwtSecret=${{ secrets.JWT_SECRET }}
+            pgadminAadClientId=${{ secrets.PGADMIN_AAD_CLIENT_ID }}
+            pgadminAadClientSecret=${{ secrets.PGADMIN_AAD_CLIENT_SECRET }}
             ${{ env.CURRENT_IMAGE != '' && format('containerImage={0}', env.CURRENT_IMAGE) || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md — Student Projects Catalogue (SPC)
+
+This file gives Claude Code persistent context about infrastructure architecture, deployment
+behaviour, and known gotchas. For the full project overview see [GEMINI.md](GEMINI.md); for
+AI coding mandates (test/lint/style rules) see [AGENTS.md](AGENTS.md); for data model, API
+contracts, and sequence diagrams see [docs/DESIGN.md](docs/DESIGN.md).
+
+---
+
+## ⚡ Quick-Reference Commands
+
+| Task | Command | Directory |
+|------|---------|-----------|
+| Start local backend | `./start.sh --reload` | `backend/` |
+| Run backend tests | `python -m pytest` | `backend/` |
+| Lint + format | `ruff check . && ruff format .` | `backend/` |
+| Start frontend | `npm run dev` | `frontend/` |
+| Run frontend tests | `npm test` | `frontend/` |
+| Generate migration | `alembic revision --autogenerate -m "..."` | `backend/` |
+| Apply migrations | `alembic upgrade head` | `backend/` |
+| Re-seed local DB | `python seed.py --reset` | `backend/` |
+| Start local infra | `docker compose up -d` | repo root |
+
+---
+
+## ☁️ Cloud vs Local: Critical Differences
+
+### `start.sh` is LOCAL ONLY
+The `Dockerfile` CMD is `uvicorn main:app` directly — `start.sh` is **never called** in the
+cloud container. It exists only as a local dev convenience that runs migrations and seeding
+before uvicorn. Do not assume cloud behaviour mirrors it.
+
+### Seeding in the cloud
+Seeding is the responsibility of the ACA migration job (`job-spc-{env}-migrate`), whose
+container command is:
+```
+/bin/sh -c "alembic upgrade head && python seed.py"
+```
+Both `DATABASE_MIGRATION_URL` and `DATABASE_URL` are set on the job so `seed.py` can connect.
+`seed.py` is idempotent — it checks `SELECT COUNT(*) FROM user` and skips if data already exists.
+
+### Scale-to-zero
+`minReplicas: 0` — the backend Container App does **not** start until the first HTTP request
+arrives. Do not assume the app is running just because it was deployed.
+
+---
+
+## 🏗️ Infrastructure Architecture
+
+### Bicep layout
+
+```
+infrastructure/
+  shared.bicep            — ACR, VNet (snet-dev/prod/db/scripts), PostgreSQL server, storage
+  environment.bicep       — top-level orchestrator; passes params into modules below
+  modules/
+    compute.bicep         — ACA environment, backend app, migration job, pgAdmin app, SWA
+    database-bootstrap.bicep — deploymentScript (ACI inside VNet) that creates DB roles
+    monitoring.bicep      — Log Analytics workspace + Application Insights (per env)
+    network.bicep         — subnet definitions
+    database.bicep        — PostgreSQL Flexible Server config
+    acr.bicep / acr-role.bicep — Container Registry + pull-role assignments
+```
+
+### DB role split (principle of least privilege)
+
+| Role | Identity | Privileges | Used by |
+|------|----------|-----------|---------|
+| `id-spc-{env}-migrator` | User-assigned MI | DDL + DML (schema owner) | Migration ACA Job |
+| `id-spc-{env}-app` | User-assigned MI | DML only (SELECT/INSERT/UPDATE/DELETE) | Running backend |
+| `{developerEmail}` | Entra ID user | Full access | pgAdmin debugging |
+
+DML grants for the `app` role are set via `ALTER DEFAULT PRIVILEGES FOR ROLE migrator`, so they
+apply automatically to every table Alembic creates.
+
+### Key Bicep parameters
+
+| Parameter / Variable | Location | Purpose |
+|---------------------|----------|---------|
+| `deployDebugTools` | `environment.bicep` param | `true` for `dev` only; gates pgAdmin ACA |
+| `deployPgadminAuth` | `compute.bicep` var | `deployDebugTools && !empty(clientId) && !empty(secret)` — EasyAuth only when both GitHub secrets are set |
+| `pgadminAadClientId` | `compute.bicep` param | App Registration client ID for EasyAuth |
+| `pgadminAadClientSecret` | `compute.bicep` param (`@secure`) | Client secret for EasyAuth |
+
+---
+
+## 🚀 CI/CD Pipeline Map
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `infrastructure.yml` | push to `infrastructure/**` or manual | Deploys shared + env Bicep |
+| `backend-dev.yml` | push to `backend/**` on `main` | Build image → run migration+seed job (polls for completion) → update ACA |
+| `frontend-dev.yml` | push to `frontend/**` on `main` | Deploy SPA to Azure Static Web App |
+
+**Migration job wait pattern**: `az containerapp job start` returns an execution name; the
+workflow polls `az containerapp job execution show` every 10 s (max 6 min) before updating the
+backend Container App.
+
+---
+
+## 🔧 Fresh Environment Setup Checklist
+
+Full commands are in [`infrastructure/README.md`](infrastructure/README.md). Summary:
+
+1. Register `Microsoft.ContainerInstance` provider (once per subscription)
+2. Create resource groups + GH service principal + role assignments
+3. Create `id-spc-shared-db-setup` identity + Graph API permissions
+4. Configure OIDC federated credentials for `main` branch, `dev` env, and pull requests
+5. Set GitHub repo-level secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, etc.)
+6. Create `dev` + `prod` GitHub environments with environment-specific secrets
+7. **Trigger Infrastructure (run 1)** — all Azure resources created; pgAdmin without EasyAuth
+8. Run Step 6 script from infra README → creates pgAdmin App Registration → add
+   `PGADMIN_AAD_CLIENT_ID` + `PGADMIN_AAD_CLIENT_SECRET` to the `dev` GitHub environment
+9. **Trigger Infrastructure (run 2)** — pgAdmin EasyAuth activates
+10. Trigger Backend deployment → Trigger Frontend deployment

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -136,12 +136,62 @@ In your GitHub repository, go to **Settings > Secrets and variables > Actions**.
 | `GEMINI_API_KEY` | API key for Gemini AI integration. | Google AI Studio |
 | `JWT_SECRET` | Secret key for signing session cookies. | [backend/.env](../backend/.env.example) |
 | `VITE_LOGIC_APP_FEEDBACK_URL` | The URL for your Logic App feedback. | Azure Portal |
+| `PGADMIN_AAD_CLIENT_ID` | App Registration client ID for pgAdmin EasyAuth (`dev` only). Leave unset until Step 6. | Step 6 |
+| `PGADMIN_AAD_CLIENT_SECRET` | Client secret for pgAdmin EasyAuth (`dev` only). Leave unset until Step 6. | Step 6 |
 
 ### Step 5: Configure GitHub Environments
 To manage differences between `dev` and `prod`:
 1.  Go to **Settings > Environments**.
 2.  Create two environments: `dev` and `prod`.
-3.  Add environment-specific secrets (like `JWT_SECRET` and `VITE_LOGIC_APP_FEEDBACK_URL`) directly to these environments.
+3.  Add `JWT_SECRET` and `VITE_LOGIC_APP_FEEDBACK_URL` to the `dev` environment now. `PGADMIN_AAD_CLIENT_ID` and `PGADMIN_AAD_CLIENT_SECRET` are added after Step 6.
+
+---
+
+### Step 6: pgAdmin App Registration (Dev Only)
+
+pgAdmin EasyAuth requires an Entra ID App Registration. Because the redirect URI must point at the deployed Container App URL, this step runs **after the first infrastructure deployment**. You need permission to create App Registrations in your Entra ID tenant (any member of the tenant can do this by default).
+
+```bash
+az login
+
+# 1. Retrieve the pgAdmin URL from the already-deployed Container App
+PGADMIN_FQDN=$(az containerapp show \
+  -n ca-spc-dev-pgadmin -g rg-spc-dev-pl \
+  --query "properties.configuration.ingress.fqdn" -o tsv)
+echo "pgAdmin FQDN: $PGADMIN_FQDN"
+
+# 2. Create the App Registration (idempotent — safe to re-run)
+APP_NAME="pgadmin-spc-dev"
+CLIENT_ID=$(az ad app list --display-name "$APP_NAME" --query "[0].appId" -o tsv)
+if [ -z "$CLIENT_ID" ]; then
+  az ad app create \
+    --display-name "$APP_NAME" \
+    --sign-in-audience AzureADMyOrg \
+    --web-redirect-uris "https://${PGADMIN_FQDN}/.auth/login/aad/callback"
+  CLIENT_ID=$(az ad app list --display-name "$APP_NAME" --query "[0].appId" -o tsv)
+else
+  # Ensure the redirect URI is up to date if re-running after a redeployment
+  az ad app update --id "$CLIENT_ID" \
+    --web-redirect-uris "https://${PGADMIN_FQDN}/.auth/login/aad/callback"
+fi
+echo "App Registration client ID: $CLIENT_ID"
+
+# 3. Create a client secret (1-year TTL; re-run with a new display-name to rotate)
+CLIENT_SECRET=$(az ad app credential reset \
+  --id "$CLIENT_ID" \
+  --display-name "easyauth-$(date +%Y)" \
+  --years 1 \
+  --query password -o tsv)
+
+echo ""
+echo "Add these as 'dev' environment secrets in GitHub (Settings → Environments → dev):"
+echo "  PGADMIN_AAD_CLIENT_ID=$CLIENT_ID"
+echo "  PGADMIN_AAD_CLIENT_SECRET=$CLIENT_SECRET"
+```
+
+After adding both secrets to GitHub, **re-run the Infrastructure Deployment** for `dev`. The `deployPgadminAuth` condition becomes true on the second run and the EasyAuth resource is created.
+
+> **Secret rotation:** Run step 3 again with a new `--display-name` (e.g. `easyauth-2027`) once per year, update the GitHub secret, and redeploy infrastructure.
 
 ---
 
@@ -182,13 +232,15 @@ az deployment group validate \
 
 ## 3. Deployment Sequence
 
-The first deployment follows an automated sequence.
+The first full deployment requires two infrastructure runs to bootstrap pgAdmin EasyAuth.
 
-1.  **Trigger Infrastructure:** Go to **Actions > Infrastructure Deployment** and run it for `dev`. 
-    *   Bicep will adopt the `id-spc-shared-db-setup` identity created in Section 2.
-    *   The `deploymentScript` will automatically create the DB roles for `dev` inside the VNet.
-2.  **Trigger Backend:** Go to **Actions > Backend Deployment (Dev)**.
-3.  **Trigger Frontend:** Go to **Actions > Frontend Deployment (Dev)**.
+1.  **Trigger Infrastructure (run 1):** Go to **Actions > Infrastructure Deployment** and run it for `dev`.
+    *   Bicep creates the DB roles and all Azure resources.
+    *   pgAdmin is deployed **without** EasyAuth on this run (`PGADMIN_AAD_CLIENT_ID` is not set yet).
+2.  **pgAdmin App Registration:** Run the script from Step 6. Add `PGADMIN_AAD_CLIENT_ID` and `PGADMIN_AAD_CLIENT_SECRET` to the `dev` GitHub environment.
+3.  **Trigger Infrastructure (run 2):** Re-run the Infrastructure Deployment for `dev`. EasyAuth is activated.
+4.  **Trigger Backend:** Go to **Actions > Backend Deployment (Dev)**.
+5.  **Trigger Frontend:** Go to **Actions > Frontend Deployment (Dev)**.
 
 ---
 
@@ -208,7 +260,7 @@ Since the PostgreSQL server is restricted to the private VNet, you cannot connec
 ### Step 1: Access the pgAdmin UI
 1.  Go to the Azure Portal and find the `ca-spc-dev-pgadmin` Container App.
 2.  Open the Application URL.
-3.  **EasyAuth:** You will be prompted to log in with your Microsoft account (`lukas.jezek@gmail.com`). This ensures only authorized developers can reach the pgAdmin login screen.
+3.  **EasyAuth:** You will be prompted to log in with your Microsoft account (`lukas.jezek@gmail.com`). If the prompt does not appear, EasyAuth is not yet configured — complete Step 6 and redeploy infrastructure first.
 
 ### Step 2: Connect to the Database
 Once inside the pgAdmin web interface, add a new server:

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -201,35 +201,32 @@ The first deployment follows an automated sequence.
 
 ---
 
-## 5. Troubleshooting & DB Debugging (VNet Access)
+## 5. Troubleshooting & DB Debugging (GUI Access)
 
-Since the PostgreSQL server is restricted to the private VNet, you cannot connect to it directly from your local machine. We use **Azure Bastion (Developer SKU)** to create a secure tunnel.
+Since the PostgreSQL server is restricted to the private VNet, you cannot connect to it directly from your local machine. We deploy a **pgAdmin Azure Container App** in the `dev` environment for secure GUI access.
 
-### Step 1: Grant your Identity Access
-By default, the `environment.bicep` grants `ALL PRIVILEGES` to `lukas.jezek@gmail.com` in the `dev` database. If you need to add another user, update the `developerIdentityEmail` parameter in `environment.bicep`.
+### Step 1: Access the pgAdmin UI
+1.  Go to the Azure Portal and find the `ca-spc-dev-pgadmin` Container App.
+2.  Open the Application URL.
+3.  **EasyAuth:** You will be prompted to log in with your Microsoft account (`lukas.jezek@gmail.com`). This ensures only authorized developers can reach the pgAdmin login screen.
 
-### Step 2: Start the Bastion Tunnel
-Run this in a terminal window. Keep it open while you are debugging.
+### Step 2: Connect to the Database
+Once inside the pgAdmin web interface, add a new server:
 
-```bash
-# 1. Get the PostgreSQL Resource ID
-DB_RESOURCE_ID=$(az postgres flexible-server show -g rg-spc-shared-pl -n psql-spc-shared --query id -o tsv)
+1.  **General Tab:**
+    *   **Name:** `spc-dev`
+2.  **Connection Tab:**
+    *   **Host:** `psql-spc-shared.postgres.database.azure.com`
+    *   **Port:** `5432`
+    *   **Maintenance Database:** `spc_dev`
+    *   **Username:** `lukas.jezek@gmail.com` (or your registered identity)
+    *   **Password:** An Entra ID Access Token. Generate it on your local machine:
+        ```bash
+        az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv
+        ```
+        *Note: The token is valid for 1 hour.*
+3.  **SSL Tab:**
+    *   **SSL Mode:** `Require`
 
-# 2. Start the tunnel (defaults to localhost:5432)
-az network bastion tunnel \
-  --name bastion-spc-shared \
-  --resource-group rg-spc-shared-pl \
-  --target-resource-id $DB_RESOURCE_ID \
-  --resource-port 5432 \
-  --port 5432
-```
-
-### Step 3: Connect using pgAdmin / DBeaver
-1.  **Host:** `localhost`
-2.  **Port:** `5432`
-3.  **Username:** `lukas.jezek@gmail.com` (your identity)
-4.  **Password:** An Entra ID Access Token. Generate it using:
-    ```bash
-    az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv
-    ```
-5.  **SSL Mode:** `Require`
+### Step 3: Cost Management
+The `pgadmin` Container App is configured to **scale to zero**. It will automatically shut down when you are not using it and start back up when you browse to its URL.

--- a/infrastructure/environment.bicep
+++ b/infrastructure/environment.bicep
@@ -13,6 +13,7 @@ param idDbSetupName string
 param storageAccountName string
 param scriptsSubnetId string
 param developerIdentityEmail string = 'lukas.jezek@gmail.com'
+param deployDebugTools bool = false
 param containerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
 @secure()
 param jwtSecret string
@@ -41,6 +42,7 @@ module compute './modules/compute.bicep' = {
     dbName: dbName
     containerImage: containerImage
     jwtSecret: jwtSecret
+    deployDebugTools: deployDebugTools
     lawId: monitoring.outputs.workspaceId
     aiConnectionString: monitoring.outputs.connectionString
   }

--- a/infrastructure/environment.bicep
+++ b/infrastructure/environment.bicep
@@ -18,6 +18,10 @@ param containerImage string = 'mcr.microsoft.com/azuredocs/containerapps-hellowo
 @secure()
 param jwtSecret string
 
+param pgadminAadClientId string = ''
+@secure()
+param pgadminAadClientSecret string = ''
+
 // --- Monitoring (Per Environment) ---
 module monitoring './modules/monitoring.bicep' = {
   name: 'monitoring-${env}-deployment'
@@ -43,6 +47,8 @@ module compute './modules/compute.bicep' = {
     containerImage: containerImage
     jwtSecret: jwtSecret
     deployDebugTools: deployDebugTools
+    pgadminAadClientId: pgadminAadClientId
+    pgadminAadClientSecret: pgadminAadClientSecret
     lawId: monitoring.outputs.workspaceId
     aiConnectionString: monitoring.outputs.connectionString
   }

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -9,6 +9,8 @@ param dbName string
 param lawId string
 param aiConnectionString string
 param containerImage string
+param deployDebugTools bool = false
+param developerIdentityEmail string = 'lukas.jezek@gmail.com'
 @secure()
 param jwtSecret string
 
@@ -184,6 +186,68 @@ resource migration_job 'Microsoft.App/jobs@2023-05-01' = {
           ]
         }
       ]
+    }
+  }
+}
+
+// --- Debugging Tools (Conditional) ---
+resource pgadmin 'Microsoft.App/containerApps@2023-05-01' = if (deployDebugTools) {
+  name: 'ca-${prefix}-${env}-pgadmin'
+  location: location
+  properties: {
+    managedEnvironmentId: env_aca.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 80
+        transport: 'auto'
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'pgadmin'
+          image: 'dpage/pgadmin4'
+          env: [
+            { name: 'PGADMIN_DEFAULT_EMAIL', value: developerIdentityEmail }
+            { name: 'PGADMIN_DEFAULT_PASSWORD', value: 'this-is-not-used-with-easyauth-123' }
+            { name: 'PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION', value: 'True' }
+            { name: 'PGADMIN_CONFIG_CONSOLE_LOG_LEVEL', value: '10' }
+          ]
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 1
+      }
+    }
+  }
+}
+
+resource pgadmin_auth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = if (deployDebugTools) {
+  parent: pgadmin
+  name: 'current'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      unauthenticatedClientAction: 'RedirectToLoginPage'
+      redirectToProvider: 'azureactivedirectory'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        registration: {
+          openIdConnectConfiguration: {
+            wellKnownOpenIdConfiguration: 'https://login.microsoftonline.com/${subscription().tenantId}/v2.0/.well-known/openid-configuration'
+          }
+        }
+      }
     }
   }
 }

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -14,7 +14,12 @@ param developerIdentityEmail string = 'lukas.jezek@gmail.com'
 @secure()
 param jwtSecret string
 
+param pgadminAadClientId string = ''
+@secure()
+param pgadminAadClientSecret string = ''
+
 var acrPullRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+var deployPgadminAuth = deployDebugTools && !empty(pgadminAadClientId) && !empty(pgadminAadClientSecret)
 
 resource law 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
   name: last(split(lawId, '/'))
@@ -176,9 +181,10 @@ resource migration_job 'Microsoft.App/jobs@2023-05-01' = {
         {
           name: 'migrator'
           image: containerImage
-          command: ['alembic', 'upgrade', 'head']
+          command: ['/bin/sh', '-c', 'alembic upgrade head && python seed.py']
           env: [
             { name: 'DATABASE_MIGRATION_URL', value: 'postgresql+asyncpg://${migrator_identity.name}@${dbHost}:5432/${dbName}' }
+            { name: 'DATABASE_URL', value: 'postgresql+asyncpg://${migrator_identity.name}@${dbHost}:5432/${dbName}' }
             { name: 'AZURE_MANAGED_IDENTITY_ENABLED', value: 'true' }
             { name: 'AZURE_CLIENT_ID', value: migrator_identity.properties.clientId }
             { name: 'APP_ENV', value: env }
@@ -202,6 +208,12 @@ resource pgadmin 'Microsoft.App/containerApps@2023-05-01' = if (deployDebugTools
         targetPort: 80
         transport: 'auto'
       }
+      secrets: deployPgadminAuth ? [
+        {
+          name: 'aad-client-secret'
+          value: pgadminAadClientSecret
+        }
+      ] : []
     }
     template: {
       containers: [
@@ -228,7 +240,7 @@ resource pgadmin 'Microsoft.App/containerApps@2023-05-01' = if (deployDebugTools
   }
 }
 
-resource pgadmin_auth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = if (deployDebugTools) {
+resource pgadmin_auth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = if (deployPgadminAuth) {
   parent: pgadmin
   name: 'current'
   properties: {
@@ -243,9 +255,15 @@ resource pgadmin_auth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = if 
       azureActiveDirectory: {
         enabled: true
         registration: {
-          openIdConnectConfiguration: {
-            wellKnownOpenIdConfiguration: 'https://login.microsoftonline.com/${subscription().tenantId}/v2.0/.well-known/openid-configuration'
-          }
+          clientId: pgadminAadClientId
+          clientSecretSettingName: 'aad-client-secret'
+          openIdIssuer: '${environment().authentication.loginEndpoint}${subscription().tenantId}/v2.0'
+        }
+        validation: {
+          allowedAudiences: [
+            'api://${pgadminAadClientId}'
+            pgadminAadClientId
+          ]
         }
       }
     }

--- a/infrastructure/shared.bicep
+++ b/infrastructure/shared.bicep
@@ -2,7 +2,6 @@ targetScope = 'resourceGroup'
 
 param location string = resourceGroup().location
 param prefix string = 'spc'
-param deployBastion bool = true
 
 // --- Network ---
 module network './modules/network.bicep' = {
@@ -41,20 +40,6 @@ module monitoring './modules/monitoring.bicep' = {
     location: location
     prefix: prefix
     env: 'shared'
-  }
-}
-
-// --- Debugging (Bastion Developer) ---
-resource bastion 'Microsoft.Network/bastionHosts@2023-11-01' = if (deployBastion) {
-  name: 'bastion-${prefix}-shared'
-  location: location
-  sku: {
-    name: 'Developer'
-  }
-  properties: {
-    virtualNetwork: {
-      id: network.outputs.vnetId
-    }
   }
 }
 


### PR DESCRIPTION
- **Replace Azure Bastion with pgAdmin ACA for DB debugging** — removes the Bastion Developer
  SKU from `shared.bicep` and adds a `dpage/pgadmin4` Azure Container App (scale-to-zero,
  dev-only) with Entra ID EasyAuth. EasyAuth only activates once two new GitHub `dev`
  environment secrets (`PGADMIN_AAD_CLIENT_ID`, `PGADMIN_AAD_CLIENT_SECRET`) are set,
  making the first infrastructure deployment safe without any pre-configured App Registration.

- **Fix missing DB seed data in cloud deployments** — the `Dockerfile` CMD is `uvicorn`
  directly; `start.sh` (which runs `seed.py`) is never called in the cloud. The ACA migration
  job now runs `alembic upgrade head && python seed.py` and has `DATABASE_URL` set so
  `seed.py` can connect using the migrator identity.

- **Fix fire-and-forget migration job** — `backend-dev.yml` previously started the migration
  job and immediately updated the backend Container App without waiting. The step now polls
  `az containerapp job execution show` every 10 s (up to 6 min) and fails the workflow if
  the job does not succeed.


Contributes to #150 