### PR TITLE
Add CSRF and XSRF protection

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import secrets
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, EmailStr, field_validator
@@ -124,6 +125,16 @@ async def verify_otp(
         samesite="strict",
         max_age=_COOKIE_MAX_AGE_SECONDS,
     )
+    # Non-HttpOnly XSRF-TOKEN cookie for Double Submit Cookie CSRF protection.
+    # JavaScript reads this value and echoes it as X-XSRF-Token on mutating requests.
+    response.set_cookie(
+        key="XSRF-TOKEN",
+        value=secrets.token_hex(32),
+        httponly=False,
+        secure=secure_cookie,
+        samesite="strict",
+        max_age=_COOKIE_MAX_AGE_SECONDS,
+    )
     return {}
 
 
@@ -151,6 +162,14 @@ async def logout(response: Response) -> dict[str, str]:
         key="session",
         value="",
         httponly=True,
+        secure=secure_cookie,
+        samesite="strict",
+        max_age=0,
+    )
+    response.set_cookie(
+        key="XSRF-TOKEN",
+        value="",
+        httponly=False,
         secure=secure_cookie,
         samesite="strict",
         max_age=0,

--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 import logging
 
 import jwt
@@ -28,14 +29,8 @@ async def get_current_user(
     Callers that require authentication should treat a ``None`` return value as
     unauthenticated and respond with an appropriate 401/403 themselves.
 
-    CSRF note: per the Double Submit Cookie spec, state-changing requests should
-    also carry an ``X-XSRF-Token`` header. That validation is intentionally
-    deferred (mocked) here while SMTP / frontend integration is still in
-    progress.
-
-    # TODO: Replace the CSRF mock below with real Double Submit Cookie validation
-    # once the frontend sends the ``X-XSRF-Token`` header on state-changing
-    # requests (PATCH, POST, DELETE).
+    CSRF protection is enforced separately via the ``verify_csrf_token``
+    dependency registered at the application level.
     """
     token = request.cookies.get("session")
     if token is None:
@@ -83,6 +78,29 @@ async def require_current_user(
             detail="Authentication is required.",
         )
     return current_user
+
+
+async def verify_csrf_token(request: Request) -> None:
+    """Enforce Double Submit Cookie CSRF protection on state-changing requests.
+
+    Safe methods (GET, HEAD, OPTIONS) are skipped.  For all mutating methods the
+    ``XSRF-TOKEN`` cookie must be present and its value must equal the
+    ``X-XSRF-Token`` request header.  Requests without the cookie (unauthenticated
+    sessions) are allowed through — downstream auth dependencies reject them.
+    """
+    if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        return
+
+    cookie_token = request.cookies.get("XSRF-TOKEN")
+    if not cookie_token:
+        return
+
+    header_token = request.headers.get("X-XSRF-Token", "")
+    if not hmac.compare_digest(cookie_token, header_token):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF token validation failed.",
+        )
 
 
 async def get_optional_current_user(

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,11 +4,12 @@ import logging
 import os
 import sys
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pythonjsonlogger.json import JsonFormatter
 
 from api.auth import router as auth_router
+from api.deps import verify_csrf_token
 from api.courses import router as courses_router
 from api.health import router as health_router
 from api.projects import router as projects_router
@@ -48,7 +49,10 @@ def _configure_logging() -> None:
 _configure_logging()
 
 settings = get_settings()
-app = FastAPI(title="Student Projects Catalogue API")
+app = FastAPI(
+    title="Student Projects Catalogue API",
+    dependencies=[Depends(verify_csrf_token)],
+)
 
 # Setup OpenTelemetry BEFORE including routers to ensure all requests are traced.
 setup_otel(app)

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,8 +9,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from pythonjsonlogger.json import JsonFormatter
 
 from api.auth import router as auth_router
-from api.deps import verify_csrf_token
 from api.courses import router as courses_router
+from api.deps import verify_csrf_token
 from api.health import router as health_router
 from api.projects import router as projects_router
 from api.users import router as users_router

--- a/backend/tests/api/test_auth_deps.py
+++ b/backend/tests/api/test_auth_deps.py
@@ -247,7 +247,7 @@ async def test_verify_csrf_token_allows_post_without_cookie() -> None:
 
 async def test_verify_csrf_token_passes_when_header_matches_cookie() -> None:
     """POST with a matching XSRF-TOKEN cookie and X-XSRF-Token header must pass."""
-    token = "a1b2c3d4e5f6"
+    token = "a1b2c3d4e5f6"  # noqa: S105
     request = MagicMock(spec=Request)
     request.method = "POST"
     request.cookies = {"XSRF-TOKEN": token}

--- a/backend/tests/api/test_auth_deps.py
+++ b/backend/tests/api/test_auth_deps.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi import HTTPException, Request
 from httpx import AsyncClient
 
-from api.deps import get_current_user, get_optional_current_user
+from api.deps import get_current_user, get_optional_current_user, verify_csrf_token
 from db.session import get_session
 from main import app
 from models.user import User, UserRole
@@ -222,6 +222,71 @@ async def test_get_optional_current_user_returns_none_without_cookie() -> None:
     result = await get_optional_current_user(request, session)
 
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for verify_csrf_token
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_csrf_token_skips_safe_methods() -> None:
+    """GET, HEAD, OPTIONS, and TRACE must bypass CSRF validation entirely."""
+    for method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        request = MagicMock(spec=Request)
+        request.method = method
+        await verify_csrf_token(request)
+
+
+async def test_verify_csrf_token_allows_post_without_cookie() -> None:
+    """POST with no XSRF-TOKEN cookie must pass — auth deps handle unauthenticated requests."""
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.cookies = {}
+    await verify_csrf_token(request)
+
+
+async def test_verify_csrf_token_passes_when_header_matches_cookie() -> None:
+    """POST with a matching XSRF-TOKEN cookie and X-XSRF-Token header must pass."""
+    token = "a1b2c3d4e5f6"
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.cookies = {"XSRF-TOKEN": token}
+    request.headers = {"X-XSRF-Token": token}
+    await verify_csrf_token(request)
+
+
+async def test_verify_csrf_token_raises_403_on_header_mismatch() -> None:
+    """POST with a mismatched X-XSRF-Token header must raise HTTP 403."""
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.cookies = {"XSRF-TOKEN": "correct"}
+    request.headers = {"X-XSRF-Token": "wrong"}
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_csrf_token(request)
+    assert exc_info.value.status_code == 403
+
+
+async def test_verify_csrf_token_raises_403_on_missing_header() -> None:
+    """POST with XSRF-TOKEN cookie but no X-XSRF-Token header must raise HTTP 403."""
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.cookies = {"XSRF-TOKEN": "secret"}
+    request.headers = {}
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_csrf_token(request)
+    assert exc_info.value.status_code == 403
+
+
+async def test_verify_csrf_token_enforces_delete_and_patch() -> None:
+    """DELETE and PATCH requests with a mismatched token must also raise HTTP 403."""
+    for method in ("DELETE", "PATCH"):
+        request = MagicMock(spec=Request)
+        request.method = method
+        request.cookies = {"XSRF-TOKEN": "secret"}
+        request.headers = {"X-XSRF-Token": "wrong"}
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_csrf_token(request)
+        assert exc_info.value.status_code == 403
 
 
 async def test_get_optional_current_user_returns_user_for_valid_token() -> None:

--- a/backend/tests/api/test_auth_logout.py
+++ b/backend/tests/api/test_auth_logout.py
@@ -48,6 +48,16 @@ async def test_logout_cookie_attributes(client: AsyncClient) -> None:
     assert "samesite=strict" in set_cookie_header.lower()
 
 
+async def test_logout_clears_xsrf_token_cookie(client: AsyncClient) -> None:
+    """Logout must expire the XSRF-TOKEN cookie by setting Max-Age=0."""
+    response = await client.post("/api/v1/auth/logout")
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    xsrf_header = next((h for h in set_cookie_headers if "XSRF-TOKEN=" in h), "")
+    assert xsrf_header, "XSRF-TOKEN Set-Cookie header not found on logout"
+    assert "Max-Age=0" in xsrf_header
+    assert "samesite=strict" in xsrf_header.lower()
+
+
 async def test_logout_is_idempotent_without_session(client: AsyncClient) -> None:
     """Calling logout without an active session must still return HTTP 200."""
     # No cookie set on the client — simulates a logged-out or anonymous caller.

--- a/backend/tests/api/test_auth_otp_verify.py
+++ b/backend/tests/api/test_auth_otp_verify.py
@@ -203,7 +203,7 @@ async def test_otp_verify_success_sets_cookie_and_marks_token_used(
 
 
 async def test_otp_verify_success_sets_xsrf_cookie(client: AsyncClient) -> None:
-    """A successful OTP verification must set a non-HttpOnly XSRF-TOKEN cookie for CSRF protection."""
+    """Successful OTP verification must set non-HttpOnly XSRF-TOKEN cookie for CSRF protection."""
     mock_user = _make_user()
     mock_token = _make_token(otp="483921")
     with (

--- a/backend/tests/api/test_auth_otp_verify.py
+++ b/backend/tests/api/test_auth_otp_verify.py
@@ -202,6 +202,28 @@ async def test_otp_verify_success_sets_cookie_and_marks_token_used(
     assert mock_mark_used.call_args[0][1] == mock_token.id
 
 
+async def test_otp_verify_success_sets_xsrf_cookie(client: AsyncClient) -> None:
+    """A successful OTP verification must set a non-HttpOnly XSRF-TOKEN cookie for CSRF protection."""
+    mock_user = _make_user()
+    mock_token = _make_token(otp="483921")
+    with (
+        patch("db.auth.get_user_by_email", new_callable=AsyncMock, return_value=mock_user),
+        patch("db.auth.get_active_otp_token", new_callable=AsyncMock, return_value=mock_token),
+        patch("db.auth.mark_otp_token_used", new_callable=AsyncMock),
+    ):
+        response = await client.post(
+            "/api/v1/auth/otp/verify",
+            json={"email": "jan.novak@tul.cz", "otp": "483921"},
+        )
+    assert response.status_code == 200
+    assert "XSRF-TOKEN" in response.cookies
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    xsrf_header = next((h for h in set_cookie_headers if "XSRF-TOKEN=" in h), "")
+    assert xsrf_header, "XSRF-TOKEN Set-Cookie header not found"
+    assert "httponly" not in xsrf_header.lower()
+    assert "samesite=strict" in xsrf_header.lower()
+
+
 async def test_otp_verify_jwt_claims_and_expiry(client: AsyncClient) -> None:
     """The session cookie JWT must carry user_id and role claims and expire in ~8 hours."""
     mock_user = _make_user(user_id=42, role=UserRole.STUDENT)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -32,6 +32,13 @@ export class ApiError extends Error {
   }
 }
 
+function getCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
 async function apiFetch<T>(path: string, options: NonNullable<Parameters<typeof fetch>[1]> = {}): Promise<T> {
   const url = `${config.apiUrl}${path}`;
   const headers = new Headers(options.headers);
@@ -40,8 +47,13 @@ async function apiFetch<T>(path: string, options: NonNullable<Parameters<typeof 
     headers.set('Content-Type', 'application/json');
   }
 
-  // TODO: Add XSRF token header for state-changing requests
-  
+  if (MUTATING_METHODS.has((options.method ?? 'GET').toUpperCase())) {
+    const xsrfToken = getCookie('XSRF-TOKEN');
+    if (xsrfToken) {
+      headers.set('X-XSRF-Token', xsrfToken);
+    }
+  }
+
   const response = await fetch(url, {
     ...options,
     headers,

--- a/infrastructure/prompts/deep-review-findings.md
+++ b/infrastructure/prompts/deep-review-findings.md
@@ -30,7 +30,7 @@ Severity labels: **HIGH** = fix before widening access · **MEDIUM** = fix soon 
 
 ---
 
-## PR 2 — CSRF Protection (Backend + Frontend, coordinated)
+## DONE PR 2 — CSRF Protection (Backend + Frontend, coordinated)
 
 **Scope:** `backend/api/deps.py`, `backend/api/auth.py`, `frontend/src/api.ts`
 
@@ -242,7 +242,7 @@ form components
 
 ---
 
-## PR 10 — Infrastructure: Health Probes, Diagnostics & CI/CD Hardening
+## DONE: PR 10 — Infrastructure: Health Probes, Diagnostics & CI/CD Hardening
 
 **Scope:** `infrastructure/modules/compute.bicep`, `backend/Dockerfile`,
 `.github/workflows/infrastructure.yml`, `.github/workflows/backend-dev.yml`,


### PR DESCRIPTION
Backend (`backend/api/deps.py`) — new `verify_csrf_token` dependency:
* Skips safe methods (GET, HEAD, OPTIONS)
* If XSRF-TOKEN cookie is absent (unauthenticated), passes through — auth deps handle 401
* If cookie present, requires X-XSRF-Token header to match via hmac.compare_digest (timing-safe); raises HTTP 403 on mismatch


**Backend** (`backend/main.py`) — verify_csrf_token registered as an app-level dependency, applying to every route automatically

**Backend** (`backend/api/auth.py`) — on successful OTP verification, sets a non-HttpOnly XSRF-TOKEN cookie (same TTL/Secure flags as session); on logout, clears it

**Frontend** (`frontend/src/api.ts`) — getCookie helper reads document cookies; apiFetch attaches X-XSRF-Token header on `POST/PUT/PATCH/DELETE` if the cookie exists

The login endpoints (`/otp/request`, `/otp/verify`) are naturally exempt — they fire before any XSRF-TOKEN cookie exists, so the if not cookie_token: return branch skips validation.


Contributes to #163 