### PR TITLE
Fix deployment script variable interpolation

### DIFF
--- a/infrastructure/modules/database-bootstrap.bicep
+++ b/infrastructure/modules/database-bootstrap.bicep
@@ -46,6 +46,7 @@ resource dbBootstrap 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
       { name: 'DB_NAME', value: dbName }
       { name: 'ENV', value: env }
       { name: 'DEV_EMAIL', value: developerIdentityEmail }
+      { name: 'AAD_ENDPOINT', value: environment().suffixes.sqlServerHostname }
     ]
     scriptContent: '''
 set -e
@@ -57,7 +58,7 @@ sleep 30
 apk update && apk add postgresql-client
 
 # Get token for PostgreSQL Entra ID authentication
-export PGPASSWORD=$(az account get-access-token --resource https://ossrdbms-aad.${environment().suffixes.sqlServerHostname} -o tsv --query accessToken)
+export PGPASSWORD=$(az account get-access-token --resource "https://ossrdbms-aad.${AAD_ENDPOINT}" -o tsv --query accessToken)
 
 echo "--- Debugging: Available Functions ---"
 psql "host=${DB_HOST} user=${DB_ADMIN} dbname=postgres sslmode=require" -c "\df *pgaad*" || echo "Failed to list functions"


### PR DESCRIPTION
Fix deployment script in `infrastructure/modules/database-bootstrap.bicep` by resolving a Bicep/Bash interpolation conflict. The bad substitution error was caused by a Bicep function call being passed literally to the shell script. Replaced with an environment variable-based approach, which is more reliable for passing dynamic values to deployment scripts.

Contributes to #150 