### PR TITLE
Fix bad interpolation in deployment script DB validation URL

### DIFF
--- a/infrastructure/modules/database-bootstrap.bicep
+++ b/infrastructure/modules/database-bootstrap.bicep
@@ -46,7 +46,7 @@ resource dbBootstrap 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
       { name: 'DB_NAME', value: dbName }
       { name: 'ENV', value: env }
       { name: 'DEV_EMAIL', value: developerIdentityEmail }
-      { name: 'AAD_ENDPOINT', value: environment().suffixes.sqlServerHostname }
+      { name: 'OSSRDBMS_RESOURCE', value: 'https://ossrdbms-aad${environment().suffixes.sqlServerHostname}/' }
     ]
     scriptContent: '''
 set -e
@@ -58,7 +58,7 @@ sleep 30
 apk update && apk add postgresql-client
 
 # Get token for PostgreSQL Entra ID authentication
-export PGPASSWORD=$(az account get-access-token --resource "https://ossrdbms-aad.$AAD_ENDPOINT" -o tsv --query accessToken)
+export PGPASSWORD=$(az account get-access-token --resource "$OSSRDBMS_RESOURCE" -o tsv --query accessToken)
 
 echo "--- Debugging: Available Functions ---"
 psql "host=${DB_HOST} user=${DB_ADMIN} dbname=postgres sslmode=require" -c "\df *pgaad*" || echo "Failed to list functions"

--- a/infrastructure/modules/database-bootstrap.bicep
+++ b/infrastructure/modules/database-bootstrap.bicep
@@ -58,7 +58,7 @@ sleep 30
 apk update && apk add postgresql-client
 
 # Get token for PostgreSQL Entra ID authentication
-export PGPASSWORD=$(az account get-access-token --resource "https://ossrdbms-aad.${AAD_ENDPOINT}" -o tsv --query accessToken)
+export PGPASSWORD=$(az account get-access-token --resource "https://ossrdbms-aad.$AAD_ENDPOINT" -o tsv --query accessToken)
 
 echo "--- Debugging: Available Functions ---"
 psql "host=${DB_HOST} user=${DB_ADMIN} dbname=postgres sslmode=require" -c "\df *pgaad*" || echo "Failed to list functions"


### PR DESCRIPTION
**Root cause:** `environment().suffixes.sqlServerHostname` is `.database.windows.net` (leading dot included), so string-interpolating it as "https://ossrdbms-aad.$AAD_ENDPOINT" in the shell produced `https://ossrdbms-aad..database.windows.net` — an invalid resource URI that caused the MSI token request to fail entirely.

**Fix:** Build the full URI in Bicep (`https://ossrdbms-aad + .database.windows.net/` = correct), pass it as `OSSRDBMS_RESOURCE`, and use it directly — no shell string manipulation needed.

Contributes to #150 