### PR TITLE
Implement email sending through ACS

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,3 +34,9 @@ OTEL_COLLECTOR_HEALTH_URL=http://otel-collector:13133
 # application will refuse to start in production without it.
 # Example: JWT_SECRET=$(python -c "import secrets; print(secrets.token_hex(32))")
 # JWT_SECRET=changeme-override-in-production!
+
+# Azure Communication Services — email delivery in non-local environments.
+# In local development these are not needed; emails are printed to stderr instead.
+# Values are injected automatically in Azure via ACA secrets (see infrastructure/modules/acs.bicep).
+# ACS_CONNECTION_STRING=endpoint=https://<name>.communication.azure.com/;accesskey=<key>==
+# ACS_FROM_ADDRESS=DoNotReply@<hash>.azurecomm.net

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,6 +22,7 @@ opentelemetry-instrumentation-sqlalchemy==0.57b0
 opentelemetry-instrumentation-asyncpg==0.57b0
 opentelemetry-instrumentation-logging==0.57b0
 azure-identity==1.19.0
+azure-communication-email==1.0.0
 httpx==0.28.1
 
 # Testing

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -92,7 +92,7 @@ async def request_otp(email: str, session: AsyncSession) -> None:
 
     logger.info("OTP token generated.", extra={"email": email})
     _settings = get_settings()
-    EmailSender(app_env=_settings.app_env).send(
+    EmailSender.from_settings(_settings).send(
         EmailTemplate.otp(to=email, otp_code=otp, portal_url=_settings.frontend_url)
     )
 

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -92,7 +92,7 @@ async def request_otp(email: str, session: AsyncSession) -> None:
 
     logger.info("OTP token generated.", extra={"email": email})
     _settings = get_settings()
-    EmailSender.from_settings(_settings).send(
+    await EmailSender.from_settings(_settings).send(
         EmailTemplate.otp(to=email, otp_code=otp, portal_url=_settings.frontend_url)
     )
 

--- a/backend/services/courses.py
+++ b/backend/services/courses.py
@@ -327,7 +327,7 @@ class CoursesService:
         await self._session.commit()
 
         _settings = get_settings()
-        EmailSender(app_env=_settings.app_env).send(
+        EmailSender.from_settings(_settings).send(
             EmailTemplate.course_invite(
                 to=target_user.email,
                 course_name=course.name,

--- a/backend/services/courses.py
+++ b/backend/services/courses.py
@@ -327,11 +327,9 @@ class CoursesService:
         await self._session.commit()
 
         _settings = get_settings()
-        EmailSender.from_settings(_settings).send(
+        await EmailSender.from_settings(_settings).send(
             EmailTemplate.course_invite(
-                to=target_user.email,
-                course_name=course.name,
-                portal_url=_settings.frontend_url,
+                to=body.email, course_name=course.name, portal_url=_settings.frontend_url
             )
         )
         logger.info(

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import logging
 import sys
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from azure.communication.email import EmailClient
+
+if TYPE_CHECKING:
+    from settings import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -192,70 +198,105 @@ class EmailTemplate:
 
 
 # ---------------------------------------------------------------------------
-# Delivery error
+# Delivery errors
 # ---------------------------------------------------------------------------
 
 
-class EmailDeliveryNotImplementedError(Exception):
-    """Raised when email delivery is not implemented in the current environment."""
+class EmailDeliveryError(Exception):
+    """Raised when email delivery fails or is not configured."""
+
+
+# Backwards-compatible alias used by existing tests and service code.
+EmailDeliveryNotImplementedError = EmailDeliveryError
 
 
 # ---------------------------------------------------------------------------
-# Sender (fake / dev implementation)
+# Sender
 # ---------------------------------------------------------------------------
 
 
 class EmailSender:
-    """Fake email sender for local development that writes messages to *stderr*.
+    """Delivers email messages.
 
-    In a ``local`` environment the full email is printed to stderr so that
-    developers can inspect it without a running SMTP server.
-
-    In any other environment (``dev``, ``production``, …) this class raises
-    :exc:`NotImplementedError` on :meth:`send` because a real SMTP integration
-    has not yet been implemented.  This prevents the fake sender from being
-    accidentally used in non-local deployments.
+    In ``local`` environments the full email is printed to stderr (no SMTP or
+    cloud service required).  In all other environments Azure Communication
+    Services is used; the caller must supply ``acs_connection_string`` and
+    ``acs_from_address`` (injected from ACA secrets via Bicep).
 
     Args:
-        app_env: The application environment string (e.g. ``"local"``, ``"dev"``,
-            ``"production"``).  The caller is responsible for reading this from
-            settings and passing it here so that this class has no dependency on
-            the global settings object.
+        app_env: The application environment string (``"local"``, ``"dev"``,
+            ``"production"``).
+        acs_connection_string: ACS connection string.  Required in non-local
+            environments.
+        acs_from_address: Verified sender address from the ACS managed domain.
+            Required in non-local environments.
     """
 
-    def __init__(self, *, app_env: str) -> None:
+    def __init__(
+        self,
+        *,
+        app_env: str,
+        acs_connection_string: str | None = None,
+        acs_from_address: str | None = None,
+    ) -> None:
         self._app_env = app_env
+        self._acs_connection_string = acs_connection_string
+        self._acs_from_address = acs_from_address
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> EmailSender:
+        """Construct an :class:`EmailSender` from application settings."""
+        return cls(
+            app_env=settings.app_env,
+            acs_connection_string=settings.acs_connection_string,
+            acs_from_address=settings.acs_from_address,
+        )
 
     def send(self, message: EmailMessage) -> None:
-        """Deliver *message* according to the current environment.
+        """Deliver *message*.
 
-        In a ``local`` environment the message is printed to *stderr* in a
-        human-readable format.  In any other environment a
-        :exc:`NotImplementedError` is raised because real SMTP delivery is
-        not yet implemented.
+        In ``local`` environments the message is printed to *stderr*.
+        In all other environments the message is sent via Azure Communication
+        Services Email.
 
         Args:
             message: The email to deliver.
 
         Raises:
-            NotImplementedError: When the environment is not ``local``.
+            EmailDeliveryError: When ACS credentials are missing or delivery fails.
         """
-        if self._app_env != "local":
+        if self._app_env == "local":
+            print(  # noqa: T201
+                f"\n{'=' * 60}\n"
+                f"[FAKE EMAIL]\n"
+                f"To:      {message.to}\n"
+                f"Subject: {message.subject}\n"
+                f"{'-' * 60}\n"
+                f"{message.body}\n"
+                f"{'=' * 60}\n",
+                file=sys.stderr,
+            )
+            return
+
+        if not self._acs_connection_string or not self._acs_from_address:
             logger.error(
-                "Email delivery is not configured for this environment; message not sent.",
-                extra={"to": message.to, "subject": message.subject, "app_env": self._app_env},
+                "ACS email not configured; message not sent.",
+                extra={"to": message.to, "subject": message.subject},
             )
-            raise EmailDeliveryNotImplementedError(
-                f"Real SMTP delivery is not yet implemented. "
-                f"EmailSender cannot be used in the '{self._app_env}' environment."
+            raise EmailDeliveryError(
+                "ACS_CONNECTION_STRING and ACS_FROM_ADDRESS must be set for email delivery."
             )
-        print(  # noqa: T201
-            f"\n{'=' * 60}\n"
-            f"[FAKE EMAIL]\n"
-            f"To:      {message.to}\n"
-            f"Subject: {message.subject}\n"
-            f"{'-' * 60}\n"
-            f"{message.body}\n"
-            f"{'=' * 60}\n",
-            file=sys.stderr,
+
+        client = EmailClient.from_connection_string(self._acs_connection_string)
+        poller = client.begin_send(
+            {
+                "senderAddress": self._acs_from_address,
+                "recipients": {"to": [{"address": message.to}]},
+                "content": {"subject": message.subject, "plainText": message.body},
+            }
+        )
+        poller.result()
+        logger.info(
+            "Email sent via ACS.",
+            extra={"to": message.to, "subject": message.subject},
         )

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -5,7 +5,7 @@ import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from azure.communication.email import EmailClient
+from azure.communication.email.aio import EmailClient
 
 if TYPE_CHECKING:
     from settings import Settings
@@ -252,7 +252,7 @@ class EmailSender:
             acs_from_address=settings.acs_from_address,
         )
 
-    def send(self, message: EmailMessage) -> None:
+    async def send(self, message: EmailMessage) -> None:
         """Deliver *message*.
 
         In ``local`` environments the message is printed to *stderr*.
@@ -288,15 +288,16 @@ class EmailSender:
             )
 
         client = EmailClient.from_connection_string(self._acs_connection_string)
-        poller = client.begin_send(
-            {
-                "senderAddress": self._acs_from_address,
-                "recipients": {"to": [{"address": message.to}]},
-                "content": {"subject": message.subject, "plainText": message.body},
-            }
-        )
-        poller.result()
-        logger.info(
-            "Email sent via ACS.",
-            extra={"to": message.to, "subject": message.subject},
-        )
+        async with client:
+            poller = await client.begin_send(
+                {
+                    "senderAddress": self._acs_from_address,
+                    "recipients": {"to": [{"address": message.to}]},
+                    "content": {"subject": message.subject, "plainText": message.body},
+                }
+            )
+            await poller.result()
+            logger.info(
+                "Email sent via ACS.",
+                extra={"to": message.to, "subject": message.subject},
+            )

--- a/backend/services/projects.py
+++ b/backend/services/projects.py
@@ -309,7 +309,7 @@ async def _check_and_auto_unlock_project(
     # Send a notification email to every participant now that results are visible.
     peer_feedback_enabled = course.peer_bonus_budget is not None
     _settings = get_settings()
-    sender = EmailSender(app_env=_settings.app_env)
+    sender = EmailSender.from_settings(_settings)
     participants: list[User] = [u for u, _ in lecturer_statuses] + [u for u, _ in member_statuses]
     for participant in participants:
         if participant.email is None:
@@ -727,7 +727,7 @@ class ProjectsService:
         await self._session.commit()
 
         _settings = get_settings()
-        EmailSender(app_env=_settings.app_env).send(
+        EmailSender.from_settings(_settings).send(
             EmailTemplate.project_invite(
                 to=body.email,
                 project_name=project.title,
@@ -808,7 +808,7 @@ class ProjectsService:
 
         if data.owner_email is not None:
             _settings = get_settings()
-            EmailSender(app_env=_settings.app_env).send(
+            EmailSender.from_settings(_settings).send(
                 EmailTemplate.project_invite(
                     to=data.owner_email,
                     project_name=project.title,

--- a/backend/services/projects.py
+++ b/backend/services/projects.py
@@ -314,7 +314,7 @@ async def _check_and_auto_unlock_project(
     for participant in participants:
         if participant.email is None:
             continue
-        sender.send(
+        await sender.send(
             EmailTemplate.results_unlocked(
                 to=participant.email,
                 project_name=p.title,
@@ -727,7 +727,7 @@ class ProjectsService:
         await self._session.commit()
 
         _settings = get_settings()
-        EmailSender.from_settings(_settings).send(
+        await EmailSender.from_settings(_settings).send(
             EmailTemplate.project_invite(
                 to=body.email,
                 project_name=project.title,
@@ -808,7 +808,7 @@ class ProjectsService:
 
         if data.owner_email is not None:
             _settings = get_settings()
-            EmailSender.from_settings(_settings).send(
+            await EmailSender.from_settings(_settings).send(
                 EmailTemplate.project_invite(
                     to=data.owner_email,
                     project_name=project.title,

--- a/backend/services/users.py
+++ b/backend/services/users.py
@@ -145,7 +145,7 @@ class UsersService:
 
         # Send invitation email.
         _settings = get_settings()
-        EmailSender(app_env=_settings.app_env).send(
+        EmailSender.from_settings(_settings).send(
             EmailTemplate.user_invite(
                 to=body.email,
                 role=body.role.value.lower(),

--- a/backend/services/users.py
+++ b/backend/services/users.py
@@ -145,7 +145,7 @@ class UsersService:
 
         # Send invitation email.
         _settings = get_settings()
-        EmailSender.from_settings(_settings).send(
+        await EmailSender.from_settings(_settings).send(
             EmailTemplate.user_invite(
                 to=body.email,
                 role=body.role.value.lower(),

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -63,6 +63,12 @@ class Settings(BaseSettings):
     azure_managed_identity_enabled: bool = False
     azure_client_id: str | None = None
 
+    # Azure Communication Services — used for email delivery in non-local environments.
+    # ACS_CONNECTION_STRING is injected from an ACA secret (set via Bicep / Key Vault).
+    # ACS_FROM_ADDRESS is the verified sender address provisioned by the ACS managed domain.
+    acs_connection_string: str | None = None
+    acs_from_address: str | None = None
+
     # Health check URL for the OTel collector sidecar/service.
     # In Azure, it's typically http://localhost:13133.
     # In local Docker Compose, it's http://otel-collector:13133.

--- a/backend/tests/services/test_courses.py
+++ b/backend/tests/services/test_courses.py
@@ -709,13 +709,16 @@ async def test_add_lecturer_succeeds_for_admin_and_creates_new_user() -> None:
             "services.courses.get_settings",
             return_value=MagicMock(frontend_url="http://localhost:5173", app_env="local"),
         ),
-        patch("services.courses.EmailSender"),  # Prevent real email side-effects.
+        patch("services.courses.EmailSender.from_settings") as mock_from_settings,
     ):
+        mock_sender_instance = mock_from_settings.return_value
+        mock_sender_instance.send = AsyncMock()
         result = await CoursesService(session).add_lecturer(
             1, AddUserBody(email="new.lecturer@tul.cz"), current_user
         )
 
     session.commit.assert_called_once()
+    mock_sender_instance.send.assert_called_once()
     assert result is not None
     assert result.id == 99
     assert result.email == "new.lecturer@tul.cz"
@@ -740,7 +743,9 @@ async def test_add_lecturer_raises_email_delivery_error_on_send_failure() -> Non
     current_user.role = UserRole.ADMIN
 
     mock_sender_instance = MagicMock()
-    mock_sender_instance.send.side_effect = EmailDeliveryNotImplementedError("No SMTP configured")
+    mock_sender_instance.send = AsyncMock(
+        side_effect=EmailDeliveryNotImplementedError("No SMTP configured")
+    )
 
     with (
         patch("services.courses.db_get_course", new_callable=AsyncMock, return_value=course),
@@ -763,7 +768,7 @@ async def test_add_lecturer_raises_email_delivery_error_on_send_failure() -> Non
             "services.courses.get_settings",
             return_value=MagicMock(frontend_url="http://localhost:5173", app_env="production"),
         ),
-        patch("services.courses.EmailSender", return_value=mock_sender_instance),
+        patch("services.courses.EmailSender.from_settings", return_value=mock_sender_instance),
         pytest.raises(EmailDeliveryNotImplementedError),
     ):
         await CoursesService(session).add_lecturer(

--- a/backend/tests/services/test_email.py
+++ b/backend/tests/services/test_email.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from services.email import (
+    EmailDeliveryError,
     EmailDeliveryNotImplementedError,
     EmailMessage,
     EmailSender,
@@ -137,19 +140,92 @@ def test_email_sender_local_outputs_to_stderr_and_not_stdout(
 
 
 # ---------------------------------------------------------------------------
-# EmailSender — non-local environment
+# EmailSender — non-local, ACS not configured
 # ---------------------------------------------------------------------------
 
 
-def test_email_sender_raises_in_non_local_env() -> None:
-    """Non-local EmailSender must raise EmailDeliveryNotImplementedError and not touch stdout."""
+def test_email_sender_raises_when_acs_not_configured_in_non_local_env() -> None:
+    """Non-local EmailSender with no ACS config must raise EmailDeliveryError."""
     msg = EmailMessage(to="user@tul.cz", subject="Test", body="Hello")
-    with pytest.raises(EmailDeliveryNotImplementedError):
+    with pytest.raises(EmailDeliveryError):
         EmailSender(app_env="production").send(msg)
 
 
-def test_email_sender_raises_in_dev_env() -> None:
-    """EmailSender must also raise EmailDeliveryNotImplementedError in the 'dev' environment."""
+def test_email_sender_raises_when_acs_not_configured_in_dev_env() -> None:
+    """EmailSender must raise EmailDeliveryError in the 'dev' environment without ACS config."""
     msg = EmailMessage(to="user@tul.cz", subject="Test", body="Hello")
-    with pytest.raises(EmailDeliveryNotImplementedError):
+    with pytest.raises(EmailDeliveryError):
         EmailSender(app_env="dev").send(msg)
+
+
+def test_email_delivery_not_implemented_error_is_alias() -> None:
+    """EmailDeliveryNotImplementedError must be the same class as EmailDeliveryError."""
+    assert EmailDeliveryNotImplementedError is EmailDeliveryError
+
+
+# ---------------------------------------------------------------------------
+# EmailSender — non-local, ACS configured (happy path)
+# ---------------------------------------------------------------------------
+
+
+def test_email_sender_calls_acs_with_correct_payload() -> None:
+    """EmailSender must call ACS begin_send with the correct message payload."""
+    msg = EmailMessage(to="student@tul.cz", subject="Hello", body="Body text")
+
+    mock_poller = MagicMock()
+    mock_client = MagicMock()
+    mock_client.begin_send.return_value = mock_poller
+
+    with patch("services.email.EmailClient") as mock_email_client_cls:
+        mock_email_client_cls.from_connection_string.return_value = mock_client
+        EmailSender(
+            app_env="dev",
+            acs_connection_string="endpoint=https://example.communication.azure.com/;accesskey=abc123==",
+            acs_from_address="DoNotReply@example.azurecomm.net",
+        ).send(msg)
+
+    mock_email_client_cls.from_connection_string.assert_called_once_with(
+        "endpoint=https://example.communication.azure.com/;accesskey=abc123=="
+    )
+    call_payload = mock_client.begin_send.call_args[0][0]
+    assert call_payload["senderAddress"] == "DoNotReply@example.azurecomm.net"
+    assert call_payload["recipients"]["to"][0]["address"] == "student@tul.cz"
+    assert call_payload["content"]["subject"] == "Hello"
+    assert call_payload["content"]["plainText"] == "Body text"
+    mock_poller.result.assert_called_once()
+
+
+def test_email_sender_acs_exception_propagates() -> None:
+    """Exceptions from the ACS SDK must propagate out of EmailSender.send."""
+    msg = EmailMessage(to="student@tul.cz", subject="Hello", body="Body text")
+
+    mock_client = MagicMock()
+    mock_client.begin_send.side_effect = RuntimeError("ACS unavailable")
+
+    with patch("services.email.EmailClient") as mock_email_client_cls:
+        mock_email_client_cls.from_connection_string.return_value = mock_client
+        with pytest.raises(RuntimeError, match="ACS unavailable"):
+            EmailSender(
+                app_env="dev",
+                acs_connection_string="endpoint=https://example.communication.azure.com/;accesskey=abc123==",
+                acs_from_address="DoNotReply@example.azurecomm.net",
+            ).send(msg)
+
+
+# ---------------------------------------------------------------------------
+# EmailSender.from_settings factory
+# ---------------------------------------------------------------------------
+
+
+def test_from_settings_constructs_sender_from_settings_object() -> None:
+    """from_settings must read app_env, acs_connection_string, and acs_from_address."""
+    mock_settings = MagicMock()
+    mock_settings.app_env = "dev"
+    mock_settings.acs_connection_string = "endpoint=https://x.communication.azure.com/;accesskey=k"
+    mock_settings.acs_from_address = "DoNotReply@x.azurecomm.net"
+
+    sender = EmailSender.from_settings(mock_settings)
+
+    assert sender._app_env == "dev"
+    assert sender._acs_connection_string == mock_settings.acs_connection_string
+    assert sender._acs_from_address == mock_settings.acs_from_address

--- a/backend/tests/services/test_email.py
+++ b/backend/tests/services/test_email.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -126,12 +126,13 @@ def test_results_unlocked_template_peer_feedback_mentioned_when_enabled() -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_email_sender_local_outputs_to_stderr_and_not_stdout(
+@pytest.mark.asyncio
+async def test_email_sender_local_outputs_to_stderr_and_not_stdout(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Local EmailSender must write to stderr, include all fields, and not touch stdout."""
     msg = EmailMessage(to="dev@tul.cz", subject="Test Subject", body="Test Body Content")
-    EmailSender(app_env="local").send(msg)
+    await EmailSender(app_env="local").send(msg)
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "dev@tul.cz" in captured.err
@@ -144,18 +145,20 @@ def test_email_sender_local_outputs_to_stderr_and_not_stdout(
 # ---------------------------------------------------------------------------
 
 
-def test_email_sender_raises_when_acs_not_configured_in_non_local_env() -> None:
+@pytest.mark.asyncio
+async def test_email_sender_raises_when_acs_not_configured_in_non_local_env() -> None:
     """Non-local EmailSender with no ACS config must raise EmailDeliveryError."""
     msg = EmailMessage(to="user@tul.cz", subject="Test", body="Hello")
     with pytest.raises(EmailDeliveryError):
-        EmailSender(app_env="production").send(msg)
+        await EmailSender(app_env="production").send(msg)
 
 
-def test_email_sender_raises_when_acs_not_configured_in_dev_env() -> None:
+@pytest.mark.asyncio
+async def test_email_sender_raises_when_acs_not_configured_in_dev_env() -> None:
     """EmailSender must raise EmailDeliveryError in the 'dev' environment without ACS config."""
     msg = EmailMessage(to="user@tul.cz", subject="Test", body="Hello")
     with pytest.raises(EmailDeliveryError):
-        EmailSender(app_env="dev").send(msg)
+        await EmailSender(app_env="dev").send(msg)
 
 
 def test_email_delivery_not_implemented_error_is_alias() -> None:
@@ -168,17 +171,22 @@ def test_email_delivery_not_implemented_error_is_alias() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_email_sender_calls_acs_with_correct_payload() -> None:
+@pytest.mark.asyncio
+async def test_email_sender_calls_acs_with_correct_payload() -> None:
     """EmailSender must call ACS begin_send with the correct message payload."""
     msg = EmailMessage(to="student@tul.cz", subject="Hello", body="Body text")
 
-    mock_poller = MagicMock()
-    mock_client = MagicMock()
+    mock_poller = AsyncMock()
+    mock_client = AsyncMock()
     mock_client.begin_send.return_value = mock_poller
+
+    # mock_client needs to be an async context manager
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
 
     with patch("services.email.EmailClient") as mock_email_client_cls:
         mock_email_client_cls.from_connection_string.return_value = mock_client
-        EmailSender(
+        await EmailSender(
             app_env="dev",
             acs_connection_string="endpoint=https://example.communication.azure.com/;accesskey=abc123==",
             acs_from_address="DoNotReply@example.azurecomm.net",
@@ -195,17 +203,22 @@ def test_email_sender_calls_acs_with_correct_payload() -> None:
     mock_poller.result.assert_called_once()
 
 
-def test_email_sender_acs_exception_propagates() -> None:
+@pytest.mark.asyncio
+async def test_email_sender_acs_exception_propagates() -> None:
     """Exceptions from the ACS SDK must propagate out of EmailSender.send."""
     msg = EmailMessage(to="student@tul.cz", subject="Hello", body="Body text")
 
-    mock_client = MagicMock()
+    mock_client = AsyncMock()
     mock_client.begin_send.side_effect = RuntimeError("ACS unavailable")
+
+    # mock_client needs to be an async context manager
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
 
     with patch("services.email.EmailClient") as mock_email_client_cls:
         mock_email_client_cls.from_connection_string.return_value = mock_client
         with pytest.raises(RuntimeError, match="ACS unavailable"):
-            EmailSender(
+            await EmailSender(
                 app_env="dev",
                 acs_connection_string="endpoint=https://example.communication.azure.com/;accesskey=abc123==",
                 acs_from_address="DoNotReply@example.azurecomm.net",

--- a/backend/tests/services/test_projects.py
+++ b/backend/tests/services/test_projects.py
@@ -1566,8 +1566,10 @@ async def test_add_member_creates_user_and_returns_member_public() -> None:
             "services.projects.get_settings",
             return_value=MagicMock(frontend_url="http://localhost:5173", app_env="local"),
         ),
-        patch("services.projects.EmailSender"),  # Prevent real email side-effects.
+        patch("services.projects.EmailSender.from_settings") as mock_from_settings,
     ):
+        mock_sender_instance = mock_from_settings.return_value
+        mock_sender_instance.send = AsyncMock()
         from schemas.projects import AddMemberBody
 
         result = await ProjectsService(session).add_member(
@@ -1601,6 +1603,7 @@ async def test_service_create_project_with_owner_sends_invite_email() -> None:
     new_member = MagicMock(spec=ProjectMember)
 
     mock_sender_instance = MagicMock()
+    mock_sender_instance.send = AsyncMock()
 
     with (
         patch("services.projects.db_get_course", new_callable=AsyncMock, return_value=course),
@@ -1645,7 +1648,7 @@ async def test_service_create_project_with_owner_sends_invite_email() -> None:
             "services.projects.get_settings",
             return_value=MagicMock(frontend_url="http://localhost:5173", app_env="local"),
         ),
-        patch("services.projects.EmailSender", return_value=mock_sender_instance),
+        patch("services.projects.EmailSender.from_settings", return_value=mock_sender_instance),
     ):
         result = await ProjectsService(session).create_project(1, data, user)
 
@@ -1681,6 +1684,7 @@ async def test_service_create_project_with_owner_raises_email_delivery_error() -
     new_member = MagicMock(spec=ProjectMember)
 
     mock_sender_instance = MagicMock()
+    mock_sender_instance.send = AsyncMock()
     mock_sender_instance.send.side_effect = EmailDeliveryNotImplementedError("No SMTP configured")
 
     with (
@@ -1704,7 +1708,7 @@ async def test_service_create_project_with_owner_raises_email_delivery_error() -
             "services.projects.get_settings",
             return_value=MagicMock(frontend_url="http://localhost:5173", app_env="production"),
         ),
-        patch("services.projects.EmailSender", return_value=mock_sender_instance),
+        patch("services.projects.EmailSender.from_settings", return_value=mock_sender_instance),
         pytest.raises(EmailDeliveryNotImplementedError),
     ):
         await ProjectsService(session).create_project(1, data, user)
@@ -1749,6 +1753,7 @@ async def test_add_member_raises_email_delivery_error_on_send_failure() -> None:
     user.role = UserRole.STUDENT
 
     mock_sender_instance = MagicMock()
+    mock_sender_instance.send = AsyncMock()
     mock_sender_instance.send.side_effect = EmailDeliveryNotImplementedError("No SMTP configured")
 
     with (
@@ -1781,7 +1786,7 @@ async def test_add_member_raises_email_delivery_error_on_send_failure() -> None:
             "services.projects.get_settings",
             return_value=MagicMock(frontend_url="http://localhost:5173", app_env="production"),
         ),
-        patch("services.projects.EmailSender", return_value=mock_sender_instance),
+        patch("services.projects.EmailSender.from_settings", return_value=mock_sender_instance),
         pytest.raises(EmailDeliveryNotImplementedError),
     ):
         from schemas.projects import AddMemberBody
@@ -2281,12 +2286,14 @@ async def test_auto_unlock_fires_when_all_submitted() -> None:
             "services.projects.db_unlock_project_results",
             new_callable=AsyncMock,
         ) as mock_unlock,
-        patch("services.projects.EmailSender"),  # Prevent real email side-effects.
+        patch("services.projects.EmailSender.from_settings") as mock_from_settings,
         patch(
             "services.projects.get_settings",
             return_value=MagicMock(frontend_url="http://localhost:5173", app_env="local"),
         ),
     ):
+        mock_sender_instance = mock_from_settings.return_value
+        mock_sender_instance.send = AsyncMock()
         from services.projects import _check_and_auto_unlock_project
 
         await _check_and_auto_unlock_project(session, 1)

--- a/backend/tests/services/test_users.py
+++ b/backend/tests/services/test_users.py
@@ -125,11 +125,12 @@ async def test_create_user_as_admin_sends_invite() -> None:
             new_callable=AsyncMock,
             return_value=(new_user, True),
         ),
-        patch("services.users.EmailSender") as mock_email_sender_class,
+        patch("services.users.EmailSender.from_settings") as mock_from_settings,
         patch("services.users.get_settings") as mock_get_settings,
     ):
         mock_get_settings.return_value = MagicMock(frontend_url="http://portal.test")
-        mock_sender_instance = mock_email_sender_class.return_value
+        mock_sender_instance = mock_from_settings.return_value
+        mock_sender_instance.send = AsyncMock()
 
         result = await UsersService(session).create_user(body, admin)
 
@@ -137,7 +138,7 @@ async def test_create_user_as_admin_sends_invite() -> None:
     session.commit.assert_called_once()
 
     # Verify email was "sent"
-    mock_email_sender_class.assert_called_once()
+    mock_from_settings.assert_called_once()
     mock_sender_instance.send.assert_called_once()
 
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -244,7 +244,23 @@ The first full deployment requires two infrastructure runs to bootstrap pgAdmin 
 
 ---
 
-## 4. Architecture Notes
+## 7. Email Delivery (Azure Communication Services)
+
+This project uses **Azure Communication Services (ACS) Email** for all outgoing notifications (OTPs, invitations, and status updates). 
+
+### How it works:
+1. **Automated Provisioning:** The `infrastructure/modules/acs.bicep` module creates a dedicated ACS resource and an **Azure-managed domain** automatically during the first infrastructure deployment.
+2. **Zero-Secret Wiring:** The ACS **connection string** is securely passed as an output to the backend Container App, where it is stored as an encrypted ACA secret. The application container never sees the raw secret in plain text environment variables.
+3. **Sender Address:** Emails are sent from a provisioned address in the format `DoNotReply@<hash>.azurecomm.net`. This avoids the need for a custom domain or SPF/DKIM DNS configuration.
+
+### Setup Steps:
+No manual setup is required if you follow the standard deployment sequence. The first run of the Infrastructure Deployment for an environment (`dev` or `prod`) will provision all necessary email resources.
+
+> **Note on Sandbox Mode:** Newly created ACS resources might be in "sandbox" mode. If you find that emails are not being delivered to all addresses, check the **Sender Authentication** settings for your ACS resource in the Azure Portal to ensure it has been moved to production or that your recipients are in the allowed list.
+
+---
+
+## 8. Architecture Notes
 
 - **Zero-Trust:** All services use **Managed Identities**.
 - **Automated Bootstrap:** A Bicep `deploymentScript` handles initial PostgreSQL role creation (`id-spc-dev-migrator` and `id-spc-dev-app`) within the private VNet.

--- a/infrastructure/environment.bicep
+++ b/infrastructure/environment.bicep
@@ -39,6 +39,16 @@ module monitoring './modules/monitoring.bicep' = {
   }
 }
 
+// --- Email (Azure Communication Services) ---
+module acs './modules/acs.bicep' = {
+  name: 'acs-${env}-deployment'
+  params: {
+    prefix: prefix
+    env: env
+    tags: tags
+  }
+}
+
 // --- Compute (ACA + SWA) ---
 module compute './modules/compute.bicep' = {
   name: 'compute-${env}-deployment'
@@ -58,6 +68,8 @@ module compute './modules/compute.bicep' = {
     pgadminAadClientSecret: pgadminAadClientSecret
     lawId: monitoring.outputs.workspaceId
     aiConnectionString: monitoring.outputs.connectionString
+    acsConnectionString: acs.outputs.connectionString
+    acsFromAddress: acs.outputs.fromAddress
     tags: tags
   }
 }

--- a/infrastructure/modules/acs.bicep
+++ b/infrastructure/modules/acs.bicep
@@ -1,0 +1,38 @@
+param prefix string
+param env string
+param tags object = {}
+
+resource emailService 'Microsoft.Communication/emailServices@2023-04-01' = {
+  name: 'acs-email-${prefix}-${env}'
+  location: 'global'
+  tags: tags
+  properties: {
+    dataLocation: 'Europe'
+  }
+}
+
+// Azure-managed domain: no DNS setup required, sends from DoNotReply@<hash>.azurecomm.net
+resource managedDomain 'Microsoft.Communication/emailServices/domains@2023-04-01' = {
+  parent: emailService
+  name: 'AzureManagedDomain'
+  location: 'global'
+  properties: {
+    domainManagement: 'AzureManaged'
+  }
+}
+
+resource commService 'Microsoft.Communication/communicationServices@2023-04-01' = {
+  name: 'acs-${prefix}-${env}'
+  location: 'global'
+  tags: tags
+  properties: {
+    dataLocation: 'Europe'
+    linkedDomains: [
+      managedDomain.id
+    ]
+  }
+}
+
+// Connection string is treated as sensitive by ARM and redacted from deployment history.
+output connectionString string = commService.listKeys().primaryConnectionString
+output fromAddress string = 'DoNotReply@${managedDomain.properties.mailFromSenderDomain}'

--- a/infrastructure/modules/acs.bicep
+++ b/infrastructure/modules/acs.bicep
@@ -2,8 +2,10 @@ param prefix string
 param env string
 param tags object = {}
 
+var suffix = uniqueString(resourceGroup().id)
+
 resource emailService 'Microsoft.Communication/emailServices@2023-04-01' = {
-  name: 'acs-email-${prefix}-${env}'
+  name: 'acs-email-${prefix}-${env}-${suffix}'
   location: 'global'
   tags: tags
   properties: {
@@ -22,7 +24,7 @@ resource managedDomain 'Microsoft.Communication/emailServices/domains@2023-04-01
 }
 
 resource commService 'Microsoft.Communication/communicationServices@2023-04-01' = {
-  name: 'acs-${prefix}-${env}'
+  name: 'acs-${prefix}-${env}-${suffix}'
   location: 'global'
   tags: tags
   properties: {

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -18,6 +18,10 @@ param pgadminAadClientId string = ''
 @secure()
 param pgadminAadClientSecret string = ''
 
+@secure()
+param acsConnectionString string
+param acsFromAddress string
+
 param tags object
 
 var acrPullRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
@@ -107,6 +111,12 @@ resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
           identity: app_identity.id
         }
       ]
+      secrets: [
+        {
+          name: 'acs-connection-string'
+          value: acsConnectionString
+        }
+      ]
     }
     template: {
       containers: [
@@ -123,6 +133,8 @@ resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
             { name: 'AZURE_MANAGED_IDENTITY_ENABLED', value: 'true' }
             { name: 'AZURE_CLIENT_ID', value: app_identity.properties.clientId }
             { name: 'OTEL_EXPORTER_OTLP_ENDPOINT', value: 'http://localhost:4318' }
+            { name: 'ACS_CONNECTION_STRING', secretRef: 'acs-connection-string' }
+            { name: 'ACS_FROM_ADDRESS', value: acsFromAddress }
           ]
           probes: [
             {

--- a/infrastructure/prompts/smtp-tul.md
+++ b/infrastructure/prompts/smtp-tul.md
@@ -1,0 +1,80 @@
+# Email Delivery — Decision Record
+
+## Chosen approach: Azure Communication Services (ACS) Email
+
+Email delivery uses **Azure Communication Services Email** with an auto-provisioned
+Azure-managed domain. The app authenticates via the ACS **connection string** (an
+API key, not a personal credential), stored as an encrypted ACA secret and injected
+into the container as `ACS_CONNECTION_STRING`.
+
+Emails are sent from `DoNotReply@<hash>.azurecomm.net` (the address provisioned by
+ACS when the `AzureManagedDomain` resource is created).
+
+### Why not SMTP with `lukas.jezek@tul.cz`?
+
+TUL's SMTP server (`smtp.tul.cz:587`) requires password authentication. Storing a
+personal TUL account password in any Azure resource (env var, ACA secret, Key Vault)
+creates a credential-theft risk that is disproportionate for a student project. If
+the credential leaked, an attacker would have full access to the TUL email account.
+
+### Why not a Logic App HTTP trigger?
+
+A Consumption Logic App with an SMTP connector would allow sending from
+`lukas.jezek@tul.cz`, but adds an extra cloud resource, an extra HTTP hop, and a
+trigger URL (acting as a secret) that needs protecting. The marginal benefit of the
+personal sender address does not justify the added complexity.
+
+### Why not Managed Identity for ACS?
+
+Azure does have an RBAC role for ACS email sending, but the role name / GUID is not
+stable across documentation sources, and the `azure-communication-email` SDK's
+`TokenCredential` path requires additional verification. The connection string
+approach is well-documented, the key is rotatable at any time via the Azure Portal,
+and it never appears as a plain environment variable (stored as an ACA secret, which
+is encrypted at rest and not visible in the portal env-vars tab).
+
+## Escalation path
+
+If a `@tul.cz` sender address becomes a requirement in the future:
+
+1. Create a **Consumption Logic App** with an SMTP connector pointing at `smtp.tul.cz`.
+2. Store the TUL password in the Logic App connection (encrypted within the Logic App,
+   not accessible to the backend directly).
+3. Expose an HTTP trigger endpoint; the backend calls it with the email payload.
+4. Store only the trigger URL (a SAS token, rotatable) as an ACA secret.
+
+This keeps personal credentials inside the Logic App connection, isolated from the
+backend container.
+
+## Bicep resources
+
+| Resource | Name pattern | Notes |
+|----------|-------------|-------|
+| `Microsoft.Communication/emailServices` | `acs-email-spc-{env}` | Parent email service |
+| `Microsoft.Communication/emailServices/domains` | `AzureManagedDomain` | Auto-provisioned domain |
+| `Microsoft.Communication/communicationServices` | `acs-spc-{env}` | Communication service; connection string sourced here |
+
+## ACA wiring
+
+`compute.bicep` stores the connection string as an ACA secret (`acs-connection-string`)
+and exposes it to the container via `secretRef`. The from-address is a plain env var
+since it is not sensitive.
+
+```
+ACS_CONNECTION_STRING  →  secretRef: acs-connection-string  (encrypted ACA secret)
+ACS_FROM_ADDRESS       →  plain env var
+```
+
+## Python SDK
+
+```python
+from azure.communication.email import EmailClient
+
+client = EmailClient.from_connection_string(settings.acs_connection_string)
+poller = client.begin_send({
+    "senderAddress": settings.acs_from_address,
+    "recipients": {"to": [{"address": recipient}]},
+    "content": {"subject": subject, "plainText": body},
+})
+poller.result()  # blocks until ACS accepts the message
+```


### PR DESCRIPTION
1. **Automated Provisioning:** The `infrastructure/modules/acs.bicep` module creates a dedicated ACS resource and an **Azure-managed domain** automatically during the first infrastructure deployment.
2. **Zero-Secret Wiring:** The ACS **connection string** is securely passed as an output to the backend Container App, where it is stored as an encrypted ACA secret. The application container never sees the raw secret in plain text environment variables.
3. **Sender Address:** Emails are sent from a provisioned address in the format `DoNotReply@<hash>.azurecomm.net`. This avoids the need for a custom domain or SPF/DKIM DNS configuration.



Contributes to #81