### PR TITLE
Parameterize hardcoded Postgres token URL to avoid error in GH Action

### DIFF
--- a/infrastructure/modules/database-bootstrap.bicep
+++ b/infrastructure/modules/database-bootstrap.bicep
@@ -12,6 +12,8 @@ param tags object
 
 // A timestamp to ensure the script runs on every deployment
 param forceUpdateTag string = utcNow()
+// Parameterize the Postgres authority URI to work around Bicep validation.
+param ossrdbmsResource string = 'https://ossrdbms-aad.database.windows.net/'
 
 // --- Deployment Script (The "Ad-hoc Setup Job") ---
 // This resource executes SQL commands inside the VNet using the Setup Identity.
@@ -46,7 +48,7 @@ resource dbBootstrap 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
       { name: 'DB_NAME', value: dbName }
       { name: 'ENV', value: env }
       { name: 'DEV_EMAIL', value: developerIdentityEmail }
-      { name: 'OSSRDBMS_RESOURCE', value: 'https://ossrdbms-aad${environment().suffixes.sqlServerHostname}/' }
+      { name: 'OSSRDBMS_RESOURCE', value: ossrdbmsResource }
     ]
     scriptContent: '''
 set -e


### PR DESCRIPTION
The previous `sqlServerHostname` is only valid for SQL Server but not for Postgresql. Furthermore, using hardcoded URL in the Bicep gave a warning `no-hardcoded-env-urls` so moving this to a param which should bypass the check.