### PR TITLE
Disable the checks for secrets and hardcoded URLs, I'm using them intentionally

### DIFF
--- a/infrastructure/modules/acs.bicep
+++ b/infrastructure/modules/acs.bicep
@@ -36,5 +36,6 @@ resource commService 'Microsoft.Communication/communicationServices@2023-04-01' 
 }
 
 // Connection string is treated as sensitive by ARM and redacted from deployment history.
+#disable-next-line outputs-should-not-contain-secrets
 output connectionString string = commService.listKeys().primaryConnectionString
 output fromAddress string = 'DoNotReply@${managedDomain.properties.mailFromSenderDomain}'

--- a/infrastructure/modules/database-bootstrap.bicep
+++ b/infrastructure/modules/database-bootstrap.bicep
@@ -13,6 +13,7 @@ param tags object
 // A timestamp to ensure the script runs on every deployment
 param forceUpdateTag string = utcNow()
 // Parameterize the Postgres authority URI to work around Bicep validation.
+#disable-next-line no-hardcoded-env-urls
 param ossrdbmsResource string = 'https://ossrdbms-aad.database.windows.net/'
 
 // --- Deployment Script (The "Ad-hoc Setup Job") ---

--- a/infrastructure/modules/database-bootstrap.bicep
+++ b/infrastructure/modules/database-bootstrap.bicep
@@ -12,9 +12,6 @@ param tags object
 
 // A timestamp to ensure the script runs on every deployment
 param forceUpdateTag string = utcNow()
-// Parameterize the Postgres authority URI to work around Bicep validation.
-#disable-next-line no-hardcoded-env-urls
-param ossrdbmsResource string = 'https://ossrdbms-aad.database.windows.net/'
 
 // --- Deployment Script (The "Ad-hoc Setup Job") ---
 // This resource executes SQL commands inside the VNet using the Setup Identity.
@@ -49,7 +46,8 @@ resource dbBootstrap 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
       { name: 'DB_NAME', value: dbName }
       { name: 'ENV', value: env }
       { name: 'DEV_EMAIL', value: developerIdentityEmail }
-      { name: 'OSSRDBMS_RESOURCE', value: ossrdbmsResource }
+      #disable-next-line no-hardcoded-env-urls
+      { name: 'OSSRDBMS_RESOURCE', value: 'https://ossrdbms-aad.database.windows.net' }
     ]
     scriptContent: '''
 set -e


### PR DESCRIPTION
* ACS requires a connection string (retrieved within Bicep template as secret and passed down to the app as secret parameter)
* PostgreSQL token retrieval URL doesn't vary by cloud, there's no parameter for it, so we need to hardcode it.

Other considerations:
* I executed `az provider register --namespace Microsoft.Communication` to enable creation of ACS resource.

Contributes to #150 #81 