### PR TITLE
Move pgAdmin to port 8080 so it doesn't fail at startup during lack of root permissions

### DIFF
--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -236,7 +236,7 @@ resource pgadmin 'Microsoft.App/containerApps@2023-05-01' = if (deployDebugTools
     configuration: {
       ingress: {
         external: true
-        targetPort: 80
+        targetPort: 8080
         transport: 'auto'
       }
       secrets: deployPgadminAuth ? [
@@ -256,6 +256,8 @@ resource pgadmin 'Microsoft.App/containerApps@2023-05-01' = if (deployDebugTools
             { name: 'PGADMIN_DEFAULT_PASSWORD', value: 'this-is-not-used-with-easyauth-123' }
             { name: 'PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION', value: 'True' }
             { name: 'PGADMIN_CONFIG_CONSOLE_LOG_LEVEL', value: '10' }
+            { name: 'PGADMIN_LISTEN_PORT', value: '8080' }
+            { name: 'PGADMIN_LISTEN_ADDRESS', value: '0.0.0.0' }
           ]
           resources: {
             cpu: json('0.25')


### PR DESCRIPTION
This should fix the problem where pgadmin container failed to start with: `Can't connect to ('::', 80); sudo: The "no new privileges" flag is set, which prevents sudo from running as root.`

Contributes to #159 