### PR TITLE
Add unit test coverage commands and reports

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -27,5 +27,10 @@ jobs:
         run: ruff check .
       - name: Run Ruff format check
         run: ruff format --check .
-      - name: Run tests
-        run: pytest
+      - name: Run tests with coverage
+        run: |
+          pytest --cov-report=term-missing | tee coverage.txt
+          echo "## Backend Test Coverage" >> $GITHUB_STEP_SUMMARY
+          echo '```text' >> $GITHUB_STEP_SUMMARY
+          cat coverage.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -25,8 +25,13 @@ jobs:
         run: npm ci
       - name: Run Lint
         run: npm run lint
-      - name: Run Unit Tests
-        run: npm test
+      - name: Run Unit Tests with Coverage
+        run: |
+          npm test -- --coverage.enabled true --coverage.reporter text | tee coverage.txt
+          echo "## Frontend Test Coverage" >> $GITHUB_STEP_SUMMARY
+          echo '```text' >> $GITHUB_STEP_SUMMARY
+          cat coverage.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
   build-and-deploy-preview:
     needs: test-and-lint-frontend

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,3 +30,16 @@ extend-immutable-calls = ["Depends", "fastapi.Depends", "Query", "fastapi.Query"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
+addopts = "--cov=. --cov-report=term-missing --cov-report=xml"
+
+[tool.coverage.run]
+omit = [
+    "migrations/*",
+    "tests/*",
+    "seed.py",
+    "seed_dev.sql",
+    "seed_production.sql",
+    "alembic.ini",
+    "migration_settings.py",
+    "*/__init__.py",
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,6 +28,7 @@ httpx==0.28.1
 # Testing
 pytest==8.3.5
 pytest-asyncio==0.24.0
+pytest-cov==6.0.0
 respx==0.22.0
 
 # Linting / formatting

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.8",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "@vitest/coverage-v8": "^3.0.0"
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,5 +31,21 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/**',
+        'dist/**',
+        'src/types.ts',
+        'src/vite-env.d.ts',
+        'src/main.tsx',
+        'vitest.setup.ts',
+        '**/*.test.tsx',
+        '**/*.test.ts',
+        '*.config.js',
+        '*.config.ts',
+      ],
+    },
   },
 });


### PR DESCRIPTION
**Backend (Python/pytest)**
   - Dependencies: Added pytest-cov to backend/requirements.txt.
   - Configuration: Updated `backend/pyproject.toml` to include coverage reporting settings.
   - Exclusions: Excluded `migrations/, tests/, seed.py, alembic.ini`, and other logic-less configuration files. Models with logic (e.g., Course) remain included.
   - GitHub Actions: Updated `.github/workflows/backend.yml` to capture coverage and display it in the workflow's Step Summary.

**Frontend (React/vitest)**
   - Dependencies: Added `@vitest/coverage-v8` to `frontend/package.json`.
   - Configuration: Updated frontend/vite.config.ts to enable and configure the v8 coverage provider.
   - Exclusions: Excluded pure type definitions (`src/types.ts`), entry point boilerplate (`src/main.tsx`), and configuration files.
   - GitHub Actions: Updated `.github/workflows/frontend.yml` to display the coverage summary directly on the GitHub workflow run page.

These changes ensure that only relevant, testable logic is measured, providing an accurate view of project test coverage both locally and in CI.

Contributes to #163 