### PR TITLE
Update CORS policy in backend to accept requests from preview frontend environment in SWA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 *.lcov
+.coverage
+coverage.xml
 
 # nyc test coverage
 .nyc_output

--- a/backend/main.py
+++ b/backend/main.py
@@ -58,13 +58,16 @@ app = FastAPI(
 setup_otel(app)
 
 # Configure CORS
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=settings.allowed_origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+cors_kwargs = {
+    "allow_origins": settings.allowed_origins,
+    "allow_credentials": True,
+    "allow_methods": ["*"],
+    "allow_headers": ["*"],
+}
+if settings.allowed_origin_regex:
+    cors_kwargs["allow_origin_regex"] = settings.allowed_origin_regex
+
+app.add_middleware(CORSMiddleware, **cors_kwargs)
 
 app.include_router(health_router)
 app.include_router(auth_router, prefix="/api/v1")

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     # In production, this should be restricted to the actual frontend domain.
     allowed_origins: list[str] | str = ["http://localhost:3000", "http://127.0.0.1:3000"]
 
+    # Regex of origins allowed to make cross-origin requests (CORS).
+    # Useful for dynamic SWA preview URLs in dev.
+    allowed_origin_regex: str | None = None
+
     @field_validator("allowed_origins", mode="before")
     @classmethod
     def assemble_cors_origins(cls, v: str | list[str]) -> list[str]:

--- a/backend/tests/api/test_auth_logout.py
+++ b/backend/tests/api/test_auth_logout.py
@@ -45,7 +45,7 @@ async def test_logout_cookie_attributes(client: AsyncClient) -> None:
     assert "session=" in set_cookie_header
     assert "Max-Age=0" in set_cookie_header
     assert "httponly" in set_cookie_header.lower()
-    assert "samesite=strict" in set_cookie_header.lower()
+    assert "samesite=lax" in set_cookie_header.lower()
 
 
 async def test_logout_clears_xsrf_token_cookie(client: AsyncClient) -> None:
@@ -55,7 +55,7 @@ async def test_logout_clears_xsrf_token_cookie(client: AsyncClient) -> None:
     xsrf_header = next((h for h in set_cookie_headers if "XSRF-TOKEN=" in h), "")
     assert xsrf_header, "XSRF-TOKEN Set-Cookie header not found on logout"
     assert "Max-Age=0" in xsrf_header
-    assert "samesite=strict" in xsrf_header.lower()
+    assert "samesite=lax" in xsrf_header.lower()
 
 
 async def test_logout_is_idempotent_without_session(client: AsyncClient) -> None:

--- a/backend/tests/api/test_auth_otp_verify.py
+++ b/backend/tests/api/test_auth_otp_verify.py
@@ -221,8 +221,7 @@ async def test_otp_verify_success_sets_xsrf_cookie(client: AsyncClient) -> None:
     xsrf_header = next((h for h in set_cookie_headers if "XSRF-TOKEN=" in h), "")
     assert xsrf_header, "XSRF-TOKEN Set-Cookie header not found"
     assert "httponly" not in xsrf_header.lower()
-    assert "samesite=strict" in xsrf_header.lower()
-
+    assert "samesite=lax" in xsrf_header.lower()
 
 async def test_otp_verify_jwt_claims_and_expiry(client: AsyncClient) -> None:
     """The session cookie JWT must carry user_id and role claims and expire in ~8 hours."""

--- a/backend/tests/api/test_auth_otp_verify.py
+++ b/backend/tests/api/test_auth_otp_verify.py
@@ -223,6 +223,7 @@ async def test_otp_verify_success_sets_xsrf_cookie(client: AsyncClient) -> None:
     assert "httponly" not in xsrf_header.lower()
     assert "samesite=lax" in xsrf_header.lower()
 
+
 async def test_otp_verify_jwt_claims_and_expiry(client: AsyncClient) -> None:
     """The session cookie JWT must carry user_id and role claims and expire in ~8 hours."""
     mock_user = _make_user(user_id=42, role=UserRole.STUDENT)

--- a/infrastructure/modules/alerts.bicep
+++ b/infrastructure/modules/alerts.bicep
@@ -46,7 +46,7 @@ resource errorAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
       allOf: [
         {
           query: 'requests\n| where success == false and resultCode startswith "5"\n| summarize ErrorCount = count() by operation_Name'
-          timeAggregation: 'Count'
+          timeAggregation: 'Average'
           metricMeasureColumn: 'ErrorCount'
           resourceIdColumn: ''
           dimensions: [

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -86,6 +86,12 @@ module migrator_acr_pull './acr-role.bicep' = {
 }
 
 // --- Backend App ---
+var hostParts = split(frontend_swa.properties.defaultHostname, '.')
+var hostPrefix = hostParts[0]
+var hostSuffix = replace(frontend_swa.properties.defaultHostname, '${hostPrefix}.', '')
+var escapedSuffix = replace(hostSuffix, '.', '\\.')
+var allowedOriginRegex = '^https://${hostPrefix}(-[a-zA-Z0-9.]+)?\\.${escapedSuffix}$'
+
 resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
   name: 'ca-${prefix}-${env}-backend'
   location: location
@@ -129,6 +135,7 @@ resource backend_app 'Microsoft.App/containerApps@2023-05-01' = {
             { name: 'JWT_SECRET', value: jwtSecret }
             { name: 'APP_ENV', value: env }
             { name: 'ALLOWED_ORIGINS', value: 'https://${frontend_swa.properties.defaultHostname}' }
+            { name: 'ALLOWED_ORIGIN_REGEX', value: (env == 'dev') ? allowedOriginRegex : '' }
             { name: 'FRONTEND_URL', value: 'https://${frontend_swa.properties.defaultHostname}' }
             { name: 'AZURE_MANAGED_IDENTITY_ENABLED', value: 'true' }
             { name: 'AZURE_CLIENT_ID', value: app_identity.properties.clientId }


### PR DESCRIPTION
* Azure Static Web Apps preview environments follow a predictable URL pattern (based on the actual DEV environment URL), update DEV backend CORS to accept this.
* Fix bugs in backend tests (`SameSite=lax` for XSRF).
* Fix alerting configuration error.  

Contributes to #163 