### PR TITLE
Loosen the CSRF check to allow OTP login (before session cookie is set)

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -85,15 +85,28 @@ async def verify_csrf_token(request: Request) -> None:
 
     Safe methods (GET, HEAD, OPTIONS) are skipped.  For all mutating methods the
     ``XSRF-TOKEN`` cookie must be present and its value must equal the
-    ``X-XSRF-Token`` request header.  Requests without the cookie (unauthenticated
-    sessions) are allowed through — downstream auth dependencies reject them.
+    ``X-XSRF-Token`` request header.
+
+    CSRF protection is only enforced for authenticated sessions (where the
+    ``session`` cookie is present).  Requests without the session cookie (e.g.,
+    initial login, public endpoints) are allowed through — downstream auth
+    dependencies handle authentication if required.
     """
     if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
         return
 
+    # If there is no session cookie, this is an unauthenticated request.
+    # We skip CSRF check for these as there is no session to hijack.
+    if not request.cookies.get("session"):
+        return
+
     cookie_token = request.cookies.get("XSRF-TOKEN")
     if not cookie_token:
-        return
+        # If session exists, XSRF-TOKEN should have been set during login.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF cookie missing.",
+        )
 
     header_token = request.headers.get("X-XSRF-Token", "")
     if not hmac.compare_digest(cookie_token, header_token):

--- a/backend/tests/api/test_auth_deps.py
+++ b/backend/tests/api/test_auth_deps.py
@@ -166,11 +166,22 @@ async def test_endpoint_returns_401_for_tampered_cookie(client: AsyncClient) -> 
     """
     # Override get_session so the DB is not required for this test.
     app.dependency_overrides[get_session] = _mock_get_session
+
+    # Ensure a clean state by clearing any cookies from previous tests
+    client.cookies.clear()
+
+    # We must provide a matching CSRF token and cookie because a session exists.
+    # Otherwise verify_csrf_token would raise 403 before reaching the auth check.
+    token = "a1b2c3d4"
     client.cookies.set("session", "eyJ.tampered.jwt")
+    client.cookies.set("XSRF-TOKEN", token)
+
     with patch("api.deps.get_settings") as mock_settings:
         mock_settings.return_value.jwt_secret = _JWT_SECRET
         # Use a protected endpoint (PATCH /projects/{id}) that requires authentication.
-        response = await client.patch("/api/v1/projects/1", json={"title": "x"})
+        response = await client.patch(
+            "/api/v1/projects/1", json={"title": "x"}, headers={"X-XSRF-Token": token}
+        )
     assert response.status_code == 401
 
 
@@ -237,52 +248,52 @@ async def test_verify_csrf_token_skips_safe_methods() -> None:
         await verify_csrf_token(request)
 
 
-async def test_verify_csrf_token_allows_post_without_cookie() -> None:
-    """POST with no XSRF-TOKEN cookie must pass — auth deps handle unauthenticated requests."""
+async def test_verify_csrf_token_allows_post_without_session_cookie() -> None:
+    """POST with no session cookie must pass — auth deps handle unauthenticated requests."""
     request = MagicMock(spec=Request)
     request.method = "POST"
     request.cookies = {}
     await verify_csrf_token(request)
 
 
-async def test_verify_csrf_token_passes_when_header_matches_cookie() -> None:
-    """POST with a matching XSRF-TOKEN cookie and X-XSRF-Token header must pass."""
+async def test_verify_csrf_token_passes_when_header_matches_cookie_with_session() -> None:
+    """POST with a matching XSRF-TOKEN cookie and X-XSRF-Token header must pass when session exists."""
     token = "a1b2c3d4e5f6"  # noqa: S105
     request = MagicMock(spec=Request)
     request.method = "POST"
-    request.cookies = {"XSRF-TOKEN": token}
+    request.cookies = {"XSRF-TOKEN": token, "session": "valid-session"}
     request.headers = {"X-XSRF-Token": token}
     await verify_csrf_token(request)
 
 
-async def test_verify_csrf_token_raises_403_on_header_mismatch() -> None:
-    """POST with a mismatched X-XSRF-Token header must raise HTTP 403."""
+async def test_verify_csrf_token_raises_403_on_header_mismatch_with_session() -> None:
+    """POST with a mismatched X-XSRF-Token header must raise HTTP 403 when session exists."""
     request = MagicMock(spec=Request)
     request.method = "POST"
-    request.cookies = {"XSRF-TOKEN": "correct"}
+    request.cookies = {"XSRF-TOKEN": "correct", "session": "valid-session"}
     request.headers = {"X-XSRF-Token": "wrong"}
     with pytest.raises(HTTPException) as exc_info:
         await verify_csrf_token(request)
     assert exc_info.value.status_code == 403
 
 
-async def test_verify_csrf_token_raises_403_on_missing_header() -> None:
-    """POST with XSRF-TOKEN cookie but no X-XSRF-Token header must raise HTTP 403."""
+async def test_verify_csrf_token_raises_403_on_missing_header_with_session() -> None:
+    """POST with XSRF-TOKEN cookie but no X-XSRF-Token header must raise HTTP 403 when session exists."""
     request = MagicMock(spec=Request)
     request.method = "POST"
-    request.cookies = {"XSRF-TOKEN": "secret"}
+    request.cookies = {"XSRF-TOKEN": "secret", "session": "valid-session"}
     request.headers = {}
     with pytest.raises(HTTPException) as exc_info:
         await verify_csrf_token(request)
     assert exc_info.value.status_code == 403
 
 
-async def test_verify_csrf_token_enforces_delete_and_patch() -> None:
-    """DELETE and PATCH requests with a mismatched token must also raise HTTP 403."""
+async def test_verify_csrf_token_enforces_delete_and_patch_with_session() -> None:
+    """DELETE and PATCH requests with a mismatched token must also raise HTTP 403 when session exists."""
     for method in ("DELETE", "PATCH"):
         request = MagicMock(spec=Request)
         request.method = method
-        request.cookies = {"XSRF-TOKEN": "secret"}
+        request.cookies = {"XSRF-TOKEN": "secret", "session": "valid-session"}
         request.headers = {"X-XSRF-Token": "wrong"}
         with pytest.raises(HTTPException) as exc_info:
             await verify_csrf_token(request)

--- a/backend/tests/api/test_auth_deps.py
+++ b/backend/tests/api/test_auth_deps.py
@@ -172,7 +172,7 @@ async def test_endpoint_returns_401_for_tampered_cookie(client: AsyncClient) -> 
 
     # We must provide a matching CSRF token and cookie because a session exists.
     # Otherwise verify_csrf_token would raise 403 before reaching the auth check.
-    token = "a1b2c3d4"
+    token = "a1b2c3d4"  # noqa: S105
     client.cookies.set("session", "eyJ.tampered.jwt")
     client.cookies.set("XSRF-TOKEN", token)
 
@@ -257,7 +257,9 @@ async def test_verify_csrf_token_allows_post_without_session_cookie() -> None:
 
 
 async def test_verify_csrf_token_passes_when_header_matches_cookie_with_session() -> None:
-    """POST with a matching XSRF-TOKEN cookie and X-XSRF-Token header must pass when session exists."""
+    """POST with a matching XSRF-TOKEN cookie and X-XSRF-Token header must pass
+    when session exists.
+    """
     token = "a1b2c3d4e5f6"  # noqa: S105
     request = MagicMock(spec=Request)
     request.method = "POST"
@@ -278,7 +280,9 @@ async def test_verify_csrf_token_raises_403_on_header_mismatch_with_session() ->
 
 
 async def test_verify_csrf_token_raises_403_on_missing_header_with_session() -> None:
-    """POST with XSRF-TOKEN cookie but no X-XSRF-Token header must raise HTTP 403 when session exists."""
+    """POST with XSRF-TOKEN cookie but no X-XSRF-Token header must raise HTTP 403
+    when session exists.
+    """
     request = MagicMock(spec=Request)
     request.method = "POST"
     request.cookies = {"XSRF-TOKEN": "secret", "session": "valid-session"}
@@ -289,7 +293,9 @@ async def test_verify_csrf_token_raises_403_on_missing_header_with_session() -> 
 
 
 async def test_verify_csrf_token_enforces_delete_and_patch_with_session() -> None:
-    """DELETE and PATCH requests with a mismatched token must also raise HTTP 403 when session exists."""
+    """DELETE and PATCH requests with a mismatched token must also raise HTTP 403
+    when session exists.
+    """
     for method in ("DELETE", "PATCH"):
         request = MagicMock(spec=Request)
         request.method = method


### PR DESCRIPTION
Login 403 Fix on preview environments: Updated CSRF middleware to skip validation for unauthenticated initial requests, resolving the login blocker in preview environments.

Contributes to #163 