### PR TITLE
Fix XSRF issue for real

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -7,7 +7,9 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, EmailStr, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.deps import require_current_user
 from db.session import get_session
+from models.user import User
 from rate_limit import rate_limit
 from services import auth_service
 from settings import get_settings
@@ -196,3 +198,40 @@ async def logout(response: Response) -> dict[str, str]:
         max_age=0,
     )
     return {}
+
+
+@router.get(
+    "/csrf-token",
+    response_model=OtpVerifyResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Refresh the CSRF token",
+    description=(
+        "Issues a fresh XSRF-TOKEN cookie and returns the token value in the response body.  "
+        "Use this on app load when the user already has a valid session but no CSRF token "
+        "in localStorage (e.g. after upgrading from an older client).  "
+        "Requires an active session; returns HTTP 401 when unauthenticated."
+    ),
+)
+async def refresh_csrf_token(
+    response: Response,
+    _current_user: User = Depends(require_current_user),
+) -> OtpVerifyResponse:
+    """Issue a new XSRF-TOKEN for the authenticated session.
+
+    GET is exempt from the global CSRF check, so this endpoint is safe to call
+    even when the client has no CSRF token yet.
+    """
+    settings = get_settings()
+    secure_cookie = settings.app_env not in ("local", "e2e")
+    samesite_policy = "none" if secure_cookie else "lax"
+
+    xsrf_token = secrets.token_hex(32)
+    response.set_cookie(
+        key="XSRF-TOKEN",
+        value=xsrf_token,
+        httponly=False,
+        secure=secure_cookie,
+        samesite=samesite_policy,
+        max_age=_COOKIE_MAX_AGE_SECONDS,
+    )
+    return OtpVerifyResponse(xsrf_token=xsrf_token)

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -47,6 +47,12 @@ class OtpVerifyResponse(BaseModel):
     xsrf_token: str
 
 
+class CsrfTokenResponse(BaseModel):
+    """Response body for the CSRF token refresh endpoint."""
+
+    xsrf_token: str
+
+
 class OtpVerifyBody(BaseModel):
     """Request body for the OTP verify endpoint."""
 
@@ -202,7 +208,7 @@ async def logout(response: Response) -> dict[str, str]:
 
 @router.get(
     "/csrf-token",
-    response_model=OtpVerifyResponse,
+    response_model=CsrfTokenResponse,
     status_code=status.HTTP_200_OK,
     summary="Refresh the CSRF token",
     description=(
@@ -215,7 +221,7 @@ async def logout(response: Response) -> dict[str, str]:
 async def refresh_csrf_token(
     response: Response,
     _current_user: User = Depends(require_current_user),
-) -> OtpVerifyResponse:
+) -> CsrfTokenResponse:
     """Issue a new XSRF-TOKEN for the authenticated session.
 
     GET is exempt from the global CSRF check, so this endpoint is safe to call
@@ -234,4 +240,4 @@ async def refresh_csrf_token(
         samesite=samesite_policy,
         max_age=_COOKIE_MAX_AGE_SECONDS,
     )
-    return OtpVerifyResponse(xsrf_token=xsrf_token)
+    return CsrfTokenResponse(xsrf_token=xsrf_token)

--- a/backend/tests/api/test_auth_csrf_token.py
+++ b/backend/tests/api/test_auth_csrf_token.py
@@ -13,7 +13,6 @@ from main import app
 from models import User
 from models.user import UserRole
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/test_auth_csrf_token.py
+++ b/backend/tests/api/test_auth_csrf_token.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import require_current_user
+from db.session import get_session
+from main import app
+from models import User
+from models.user import UserRole
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _override_session() -> Generator[None, None, None]:
+    app.dependency_overrides[get_session] = lambda: MagicMock(spec=AsyncSession)
+    yield
+    app.dependency_overrides.pop(get_session, None)
+
+
+@pytest.fixture(autouse=True)
+def _mock_settings() -> Generator[None, None, None]:
+    mock_settings = MagicMock()
+    mock_settings.app_env = "local"
+    with patch("api.auth.get_settings", return_value=mock_settings):
+        yield
+
+
+def _make_user(user_id: int = 1) -> MagicMock:
+    user = MagicMock(spec=User)
+    user.id = user_id
+    user.role = UserRole.STUDENT
+    return user
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/auth/csrf-token
+# ---------------------------------------------------------------------------
+
+
+async def test_csrf_token_returns_401_when_unauthenticated(client: AsyncClient) -> None:
+    """GET /api/v1/auth/csrf-token must return 401 when no session exists."""
+    # No require_current_user override → the real dependency raises 401.
+    response = await client.get("/api/v1/auth/csrf-token")
+    assert response.status_code == 401
+
+
+async def test_csrf_token_returns_200_with_token_for_authenticated_user(
+    client: AsyncClient,
+) -> None:
+    """Returns 200 with an xsrf_token string in the body for an active session."""
+    app.dependency_overrides[require_current_user] = lambda: _make_user()
+    try:
+        response = await client.get("/api/v1/auth/csrf-token")
+    finally:
+        app.dependency_overrides.pop(require_current_user, None)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "xsrf_token" in body
+    assert isinstance(body["xsrf_token"], str) and len(body["xsrf_token"]) > 0
+
+
+async def test_csrf_token_sets_non_httponly_cookie(client: AsyncClient) -> None:
+    """The XSRF-TOKEN cookie must be readable by JavaScript (not HttpOnly)."""
+    app.dependency_overrides[require_current_user] = lambda: _make_user()
+    try:
+        response = await client.get("/api/v1/auth/csrf-token")
+    finally:
+        app.dependency_overrides.pop(require_current_user, None)
+
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    xsrf_header = next((h for h in set_cookie_headers if "XSRF-TOKEN=" in h), "")
+    assert xsrf_header, "XSRF-TOKEN Set-Cookie header not found"
+    assert "httponly" not in xsrf_header.lower()
+    assert "samesite=lax" in xsrf_header.lower()
+
+
+async def test_csrf_token_body_matches_cookie(client: AsyncClient) -> None:
+    """The xsrf_token in the body must equal the XSRF-TOKEN cookie value."""
+    app.dependency_overrides[require_current_user] = lambda: _make_user()
+    try:
+        response = await client.get("/api/v1/auth/csrf-token")
+    finally:
+        app.dependency_overrides.pop(require_current_user, None)
+
+    assert response.json()["xsrf_token"] == response.cookies["XSRF-TOKEN"]
+
+
+async def test_csrf_token_each_call_generates_unique_token(client: AsyncClient) -> None:
+    """Each call must produce a different token (tokens are not reused)."""
+    app.dependency_overrides[require_current_user] = lambda: _make_user()
+    try:
+        r1 = await client.get("/api/v1/auth/csrf-token")
+        r2 = await client.get("/api/v1/auth/csrf-token")
+    finally:
+        app.dependency_overrides.pop(require_current_user, None)
+
+    assert r1.json()["xsrf_token"] != r2.json()["xsrf_token"]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -34,7 +34,7 @@ const _CSRF_STORAGE_KEY = 'xsrf-token';
 // localStorage on each request so that cross-tab logout/login stays consistent.
 let _csrfTokenFallback: string | null = null;
 
-function getStoredCsrfToken(): string | null {
+export function getStoredCsrfToken(): string | null {
   try { return localStorage.getItem(_CSRF_STORAGE_KEY); } catch { return _csrfTokenFallback; }
 }
 
@@ -149,6 +149,11 @@ export async function logout(): Promise<void> {
   } finally {
     clearCsrfToken();
   }
+}
+
+export async function refreshCsrfToken(): Promise<void> {
+  const { xsrf_token } = await apiFetch<{ xsrf_token: string }>('/api/v1/auth/csrf-token');
+  storeCsrfToken(xsrf_token);
 }
 
 export async function getUsers(): Promise<UserPublic[]> {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { UserPublic } from '@/types';
-import { getCurrentUser, verifyOtp, logout as apiLogout, ApiError, storeCsrfToken } from '@/api';
+import { getCurrentUser, verifyOtp, logout as apiLogout, refreshCsrfToken, ApiError, storeCsrfToken, getStoredCsrfToken } from '@/api';
 
 interface AuthContextType {
   user: UserPublic | null;
@@ -27,6 +27,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     try {
       const userData = await getCurrentUser();
       setUser(userData);
+      // Recover CSRF token for sessions that pre-date the localStorage approach.
+      if (!getStoredCsrfToken()) {
+        try { await refreshCsrfToken(); } catch { /* best-effort */ }
+      }
     } catch (error) {
       // Only clear the user session on authentication errors (401).
       // Transient failures (network errors, 5xx) should not log the user out.

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -29,7 +29,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       setUser(userData);
       // Recover CSRF token for sessions that pre-date the localStorage approach.
       if (!getStoredCsrfToken()) {
-        try { await refreshCsrfToken(); } catch { /* best-effort */ }
+        try { await refreshCsrfToken(); } catch { /* Non-fatal: a token refresh failure should not block app load. */ }
       }
     } catch (error) {
       // Only clear the user session on authentication errors (401).


### PR DESCRIPTION
Fix 403 on Azure POSTs (except for OTH auth): 403s happened because `document.cookie` on the SWA frontend domain (`*.azurestaticapps.net`) cannot read cookies set by the ACA backend domain (`*.azurecontainerapps.io`) — browsers block this by design. The old CSRF check worked when both domains were the same (localhost), but broke in Azure.

* Return the token in the body (not just the cookie), which is the only way a cross-origin frontend can get it, since `document.cookie` cannot read cookies set on a different domain.

Contributes to #181 