### PR TITLE
Fix SMTP password wiring from environment rather than global secrets

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -57,14 +57,7 @@ jobs:
     with:
       environment: dev
       deploy_debug_tools: true
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
-      PGADMIN_AAD_CLIENT_ID: ${{ secrets.PGADMIN_AAD_CLIENT_ID }}
-      PGADMIN_AAD_CLIENT_SECRET: ${{ secrets.PGADMIN_AAD_CLIENT_SECRET }}
+    secrets: inherit
 
   deploy-prod:
     name: "Deploy Prod"
@@ -78,9 +71,4 @@ jobs:
     with:
       environment: prod
       deploy_debug_tools: false
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+    secrets: inherit

--- a/.github/workflows/reusable-infra-env.yml
+++ b/.github/workflows/reusable-infra-env.yml
@@ -24,7 +24,7 @@ on:
       PGADMIN_AAD_CLIENT_SECRET:
         required: false
       SMTP_PASSWORD:
-        required: true
+        required: false
 
 jobs:
   deploy:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -46,8 +46,8 @@ OTEL_COLLECTOR_HEALTH_URL=http://otel-collector:13133
 # The password is stored as an encrypted ACA secret; all other fields are plain env vars.
 #
 # Sign up at https://smtp2go.com, verify jezci.net, and create an SMTP user to get these values.
-# SMTP_HOST=mail.smtp2go.com
+# SMTP_HOST=smtp.tul.cz
 # SMTP_PORT=587
-# SMTP_USERNAME=your-smtp2go-smtp-username
-# SMTP_PASSWORD=your-smtp2go-smtp-password
-# SMTP_FROM_ADDRESS=tul-projects@jezci.net
+# SMTP_USERNAME=lukas.jezek@tul.cz
+# SMTP_PASSWORD=your-smtp-password
+# SMTP_FROM_ADDRESS=lukas.jezek@tul.cz

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -84,6 +84,20 @@ class Settings(BaseSettings):
     smtp_password: str | None = None  # injected as an encrypted ACA secret
     smtp_from_address: str = "lukas.jezek@tul.cz"
 
+    @field_validator("smtp_password", mode="before")
+    @classmethod
+    def _normalise_smtp_password(cls, v: object) -> object:
+        """Treat an empty-string SMTP_PASSWORD env var as absent (None).
+
+        Azure Container Apps injects a blank string when the ACA secret has no
+        value (e.g. the GitHub secret was not yet configured). An empty string
+        is falsy but is not None, which would silently bypass the None-guard in
+        EmailSender and trigger the 'not configured' error path.
+        """
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
+
     # Health check URL for the OTel collector sidecar/service.
     # In Azure, it's typically http://localhost:13133.
     # In local Docker Compose, it's http://otel-collector:13133.

--- a/infrastructure/environment.bicep
+++ b/infrastructure/environment.bicep
@@ -22,7 +22,7 @@ param smtpHost string = 'smtp.tul.cz'
 param smtpPort int = 587
 param smtpUsername string = 'lukas.jezek@tul.cz'
 @secure()
-param smtpPassword string
+param smtpPassword string = ''
 param smtpFromAddress string = 'lukas.jezek@tul.cz'
 
 param pgadminAadClientId string = ''

--- a/infrastructure/modules/compute.bicep
+++ b/infrastructure/modules/compute.bicep
@@ -22,7 +22,7 @@ param smtpHost string = 'smtp.tul.cz'
 param smtpPort int = 587
 param smtpUsername string = 'lukas.jezek@tul.cz'
 @secure()
-param smtpPassword string
+param smtpPassword string = ''
 param smtpFromAddress string = 'lukas.jezek@tul.cz'
 
 param tags object


### PR DESCRIPTION
The original code was incorrectly reading global GH secrets, but we have SMTP_PASSWORD in environment secrets

#81 